### PR TITLE
feat: self-hosted runner pilot for docker-piwine-office

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - piwine-office

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -99,7 +99,6 @@ jobs:
       - name: Get changed files (for removal detection)
         id: changed-files
         if: steps.previous-sha.outputs.previous_sha != inputs.target-ref
-        continue-on-error: true
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           json: true

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -53,6 +53,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       previous_sha: ${{ steps.previous-sha.outputs.previous_sha }}
+      has_previous_sha: ${{ steps.previous-sha.outputs.has_previous_sha }}
       removed_stacks: ${{ steps.detect-changes.outputs.removed_stacks }}
       existing_stacks: ${{ steps.detect-changes.outputs.existing_stacks }}
       new_stacks: ${{ steps.detect-changes.outputs.new_stacks }}
@@ -81,9 +82,11 @@ jobs:
           CURRENT_SHA=$(git -C "$LIVE_REPO_PATH" rev-parse HEAD 2>/dev/null || echo "")
           if [[ "$CURRENT_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; then
             echo "previous_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+            echo "has_previous_sha=true" >> "$GITHUB_OUTPUT"
             echo "✅ previous_sha=$CURRENT_SHA"
           else
             echo "previous_sha=HEAD^" >> "$GITHUB_OUTPUT"
+            echo "has_previous_sha=false" >> "$GITHUB_OUTPUT"
             echo "⚠️  Live tree HEAD unreadable — using HEAD^ as fallback"
           fi
 
@@ -130,8 +133,15 @@ jobs:
         run: |
           set -euo pipefail
           for stack in $(echo "$REMOVED_STACKS" | jq -r '.[]'); do
-            compose_file="$LIVE_REPO_PATH/$stack/compose.yaml"
-            if [[ -f "$compose_file" ]]; then
+            [[ "$stack" =~ ^[a-zA-Z0-9._-]+$ ]] || { echo "::error::invalid stack name: $stack"; exit 1; }
+            compose_file=""
+            for ext in yaml yml; do
+              if [[ -f "$LIVE_REPO_PATH/$stack/compose.$ext" ]]; then
+                compose_file="$LIVE_REPO_PATH/$stack/compose.$ext"
+                break
+              fi
+            done
+            if [[ -n "$compose_file" ]]; then
               echo "🛑 Stopping $stack"
               docker compose -f "$compose_file" down || echo "::warning::down failed for $stack"
             else
@@ -147,6 +157,8 @@ jobs:
       && (needs.teardown-removed.result == 'success' || needs.teardown-removed.result == 'skipped')
     runs-on: [self-hosted, piwine-office]
     timeout-minutes: 5
+    outputs:
+      skipped: ${{ steps.gate.outputs.skipped }}
     env:
       LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
       TARGET_REF: ${{ inputs.target-ref }}
@@ -176,6 +188,7 @@ jobs:
     needs: [prepare, update-tree]
     if: |
       always() && needs.update-tree.result == 'success'
+      && needs.update-tree.outputs.skipped == 'false'
       && inputs.has-dockge
     runs-on: [self-hosted, piwine-office]
     timeout-minutes: 10
@@ -196,6 +209,7 @@ jobs:
     if: |
       always()
       && needs.update-tree.result == 'success'
+      && needs.update-tree.outputs.skipped == 'false'
       && (needs.deploy-dockge.result == 'success' || needs.deploy-dockge.result == 'skipped')
       && needs.prepare.outputs.has_existing_stacks == 'true'
     runs-on: [self-hosted, piwine-office]
@@ -213,6 +227,7 @@ jobs:
       - name: Pull and deploy ${{ matrix.stack }}
         run: |
           set -euo pipefail
+          [[ "$STACK" =~ ^[a-zA-Z0-9._-]+$ ]] || { echo "::error::invalid stack name: $STACK"; exit 1; }
           cd "$LIVE_REPO_PATH/$STACK"
           timeout "$IMAGE_PULL_TIMEOUT" docker compose pull
           timeout "$SERVICE_STARTUP_TIMEOUT" docker compose up -d --wait
@@ -222,6 +237,7 @@ jobs:
     if: |
       always()
       && needs.update-tree.result == 'success'
+      && needs.update-tree.outputs.skipped == 'false'
       && (needs.deploy-existing.result == 'success' || needs.deploy-existing.result == 'skipped')
       && needs.prepare.outputs.has_new_stacks == 'true'
     runs-on: [self-hosted, piwine-office]
@@ -239,6 +255,7 @@ jobs:
       - name: Pull and deploy ${{ matrix.stack }}
         run: |
           set -euo pipefail
+          [[ "$STACK" =~ ^[a-zA-Z0-9._-]+$ ]] || { echo "::error::invalid stack name: $STACK"; exit 1; }
           cd "$LIVE_REPO_PATH/$STACK"
           timeout "$IMAGE_PULL_TIMEOUT" docker compose pull
           timeout "$SERVICE_STARTUP_TIMEOUT" docker compose up -d --wait
@@ -249,7 +266,7 @@ jobs:
       always()
       && (needs.deploy-existing.result == 'success' || needs.deploy-existing.result == 'skipped')
       && (needs.deploy-new.result == 'success' || needs.deploy-new.result == 'skipped')
-      && (needs.deploy-existing.result != 'skipped' || needs.deploy-new.result != 'skipped')
+      && (needs.deploy-existing.result == 'success' || needs.deploy-new.result == 'success')
     runs-on: [self-hosted, piwine-office]
     timeout-minutes: 5
     outputs:
@@ -284,7 +301,7 @@ jobs:
     needs: [prepare, deploy-existing, deploy-new, health-check]
     if: |
       always()
-      && needs.prepare.outputs.previous_sha != 'HEAD^'
+      && needs.prepare.outputs.has_previous_sha == 'true'
       && (needs.deploy-existing.result == 'failure'
           || needs.deploy-new.result == 'failure'
           || needs.health-check.result == 'failure')
@@ -294,6 +311,27 @@ jobs:
       LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
       PREVIOUS_SHA: ${{ needs.prepare.outputs.previous_sha }}
     steps:
+      - name: Tear down new stacks (will not exist after reset)
+        if: needs.prepare.outputs.has_new_stacks == 'true'
+        env:
+          NEW_STACKS: ${{ needs.prepare.outputs.new_stacks }}
+        run: |
+          set -euo pipefail
+          for stack in $(echo "$NEW_STACKS" | jq -r '.[]'); do
+            [[ "$stack" =~ ^[a-zA-Z0-9._-]+$ ]] || { echo "::error::invalid stack name: $stack"; exit 1; }
+            compose_file=""
+            for ext in yaml yml; do
+              if [[ -f "$LIVE_REPO_PATH/$stack/compose.$ext" ]]; then
+                compose_file="$LIVE_REPO_PATH/$stack/compose.$ext"
+                break
+              fi
+            done
+            if [[ -n "$compose_file" ]]; then
+              echo "🛑 Tearing down new stack $stack before rollback"
+              docker compose -f "$compose_file" down || echo "::warning::down failed for $stack"
+            fi
+          done
+
       - name: Reset live tree to previous SHA
         run: git -C "$LIVE_REPO_PATH" reset --hard "$PREVIOUS_SHA"
 
@@ -301,7 +339,7 @@ jobs:
         run: |
           set -euo pipefail
           for stack_dir in "$LIVE_REPO_PATH"/*/; do
-            [[ -f "$stack_dir/compose.yaml" ]] || continue
+            [[ -f "$stack_dir/compose.yaml" || -f "$stack_dir/compose.yml" ]] || continue
             cd "$stack_dir"
             docker compose pull || true
             docker compose up -d --wait || echo "::warning::rollback up failed for $stack_dir"
@@ -320,6 +358,7 @@ jobs:
         run: |
           set -euo pipefail
           for stack in $(echo "$NEW_STACKS" | jq -r '.[]'); do
+            [[ "$stack" =~ ^[a-zA-Z0-9._-]+$ ]] || { echo "::error::invalid stack name: $stack"; exit 1; }
             cd "$LIVE_REPO_PATH/$stack" 2>/dev/null || continue
             docker compose down || true
           done

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -1,0 +1,514 @@
+---
+name: Deploy (Local Self-Hosted)
+
+on:
+  workflow_call:
+    inputs:
+      live-repo-path:
+        description: "Absolute path to the live compose tree on the runner host"
+        required: true
+        type: string
+      live-dockge-path:
+        description: "Absolute path to dockge's compose tree (when has-dockge=true)"
+        required: false
+        type: string
+        default: /opt/dockge
+      repo-name:
+        required: true
+        type: string
+      webhook-url:
+        required: true
+        type: string
+      discord-user-id:
+        required: true
+        type: string
+      target-ref:
+        required: true
+        type: string
+      has-dockge:
+        type: boolean
+        default: false
+      force-deploy:
+        type: boolean
+        default: false
+      auto-detect-critical:
+        type: boolean
+        default: true
+      critical-services:
+        type: string
+        default: '[]'
+      image-pull-timeout:
+        type: number
+        default: 600
+      service-startup-timeout:
+        type: number
+        default: 300
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    outputs:
+      previous_sha: ${{ steps.previous-sha.outputs.previous_sha }}
+      removed_stacks: ${{ steps.detect-changes.outputs.removed_stacks }}
+      existing_stacks: ${{ steps.detect-changes.outputs.existing_stacks }}
+      new_stacks: ${{ steps.detect-changes.outputs.new_stacks }}
+      has_removed_stacks: ${{ steps.detect-changes.outputs.has_removed_stacks }}
+      has_existing_stacks: ${{ steps.detect-changes.outputs.has_existing_stacks }}
+      has_new_stacks: ${{ steps.detect-changes.outputs.has_new_stacks }}
+      critical_stacks: ${{ steps.detect-critical.outputs.critical_stacks }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.target-ref }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: owine/compose-workflow
+          ref: main
+          path: .compose-workflow
+
+      - name: Capture previous deployment SHA from live tree
+        id: previous-sha
+        env:
+          LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+        run: |
+          set -euo pipefail
+          CURRENT_SHA=$(git -C "$LIVE_REPO_PATH" rev-parse HEAD 2>/dev/null || echo "")
+          if [[ "$CURRENT_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; then
+            echo "previous_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+            echo "✅ previous_sha=$CURRENT_SHA"
+          else
+            echo "previous_sha=HEAD^" >> "$GITHUB_OUTPUT"
+            echo "⚠️  Live tree HEAD unreadable — using HEAD^ as fallback"
+          fi
+
+      - name: Get changed files (for removal detection)
+        id: changed-files
+        if: steps.previous-sha.outputs.previous_sha != inputs.target-ref
+        continue-on-error: true
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
+        with:
+          json: true
+          sha: ${{ inputs.target-ref }}
+          base_sha: ${{ steps.previous-sha.outputs.previous_sha }}
+
+      - name: Detect stack changes
+        id: detect-changes
+        env:
+          LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+          PREVIOUS_SHA: ${{ steps.previous-sha.outputs.previous_sha }}
+          TARGET_REF: ${{ inputs.target-ref }}
+          REMOVED_FILES: ${{ steps.changed-files.outputs.deleted_files }}
+        run: |
+          ./.compose-workflow/scripts/deployment/detect-stack-changes.sh \
+            --mode local \
+            --current-sha "$PREVIOUS_SHA" \
+            --target-ref "$TARGET_REF" \
+            --live-repo-path "$LIVE_REPO_PATH" \
+            --removed-files "$REMOVED_FILES"
+
+      - name: Detect critical stacks
+        id: detect-critical
+        if: inputs.auto-detect-critical
+        run: ./.compose-workflow/scripts/deployment/detect-critical-stacks.sh
+
+  teardown-removed:
+    needs: prepare
+    if: needs.prepare.outputs.has_removed_stacks == 'true'
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 10
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      REMOVED_STACKS: ${{ needs.prepare.outputs.removed_stacks }}
+    steps:
+      - name: Stop removed stacks (uses pre-reset compose files)
+        run: |
+          set -euo pipefail
+          for stack in $(echo "$REMOVED_STACKS" | jq -r '.[]'); do
+            compose_file="$LIVE_REPO_PATH/$stack/compose.yaml"
+            if [[ -f "$compose_file" ]]; then
+              echo "🛑 Stopping $stack"
+              docker compose -f "$compose_file" down || echo "::warning::down failed for $stack"
+            else
+              echo "::warning::compose file missing for removed stack $stack"
+            fi
+          done
+
+  update-tree:
+    needs: [prepare, teardown-removed]
+    # Run if teardown-removed succeeded OR was skipped (no removed stacks)
+    if: |
+      always() && needs.prepare.result == 'success'
+      && (needs.teardown-removed.result == 'success' || needs.teardown-removed.result == 'skipped')
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      TARGET_REF: ${{ inputs.target-ref }}
+      FORCE_DEPLOY: ${{ inputs.force-deploy }}
+    steps:
+      - name: Skip if already at target SHA (and not forced)
+        id: gate
+        run: |
+          set -euo pipefail
+          CURRENT_SHA=$(git -C "$LIVE_REPO_PATH" rev-parse HEAD)
+          if [[ "$CURRENT_SHA" == "$TARGET_REF" && "$FORCE_DEPLOY" != "true" ]]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  Already at $TARGET_REF; skipping update"
+          else
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update live tree
+        if: steps.gate.outputs.skipped == 'false'
+        run: |
+          set -euo pipefail
+          git -C "$LIVE_REPO_PATH" fetch
+          git -C "$LIVE_REPO_PATH" reset --hard "$TARGET_REF"
+          echo "✅ live tree now at $TARGET_REF"
+
+  deploy-dockge:
+    needs: [prepare, update-tree]
+    if: |
+      always() && needs.update-tree.result == 'success'
+      && inputs.has-dockge
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 10
+    env:
+      DOCKGE_PATH: ${{ inputs.live-dockge-path }}
+      IMAGE_PULL_TIMEOUT: ${{ inputs.image-pull-timeout }}
+      SERVICE_STARTUP_TIMEOUT: ${{ inputs.service-startup-timeout }}
+    steps:
+      - name: Pull and start dockge
+        run: |
+          set -euo pipefail
+          cd "$DOCKGE_PATH"
+          timeout "$IMAGE_PULL_TIMEOUT" docker compose pull
+          timeout "$SERVICE_STARTUP_TIMEOUT" docker compose up -d --wait
+
+  deploy-existing:
+    needs: [prepare, update-tree, deploy-dockge]
+    if: |
+      always()
+      && needs.update-tree.result == 'success'
+      && (needs.deploy-dockge.result == 'success' || needs.deploy-dockge.result == 'skipped')
+      && needs.prepare.outputs.has_existing_stacks == 'true'
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        stack: ${{ fromJSON(needs.prepare.outputs.existing_stacks) }}
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      IMAGE_PULL_TIMEOUT: ${{ inputs.image-pull-timeout }}
+      SERVICE_STARTUP_TIMEOUT: ${{ inputs.service-startup-timeout }}
+      STACK: ${{ matrix.stack }}
+    steps:
+      - name: Pull and deploy ${{ matrix.stack }}
+        run: |
+          set -euo pipefail
+          cd "$LIVE_REPO_PATH/$STACK"
+          timeout "$IMAGE_PULL_TIMEOUT" docker compose pull
+          timeout "$SERVICE_STARTUP_TIMEOUT" docker compose up -d --wait
+
+  deploy-new:
+    needs: [prepare, update-tree, deploy-existing]
+    if: |
+      always()
+      && needs.update-tree.result == 'success'
+      && (needs.deploy-existing.result == 'success' || needs.deploy-existing.result == 'skipped')
+      && needs.prepare.outputs.has_new_stacks == 'true'
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        stack: ${{ fromJSON(needs.prepare.outputs.new_stacks) }}
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      IMAGE_PULL_TIMEOUT: ${{ inputs.image-pull-timeout }}
+      SERVICE_STARTUP_TIMEOUT: ${{ inputs.service-startup-timeout }}
+      STACK: ${{ matrix.stack }}
+    steps:
+      - name: Pull and deploy ${{ matrix.stack }}
+        run: |
+          set -euo pipefail
+          cd "$LIVE_REPO_PATH/$STACK"
+          timeout "$IMAGE_PULL_TIMEOUT" docker compose pull
+          timeout "$SERVICE_STARTUP_TIMEOUT" docker compose up -d --wait
+
+  health-check:
+    needs: [prepare, deploy-existing, deploy-new]
+    if: |
+      always()
+      && (needs.deploy-existing.result == 'success' || needs.deploy-existing.result == 'skipped')
+      && (needs.deploy-new.result == 'success' || needs.deploy-new.result == 'skipped')
+      && (needs.deploy-existing.result != 'skipped' || needs.deploy-new.result != 'skipped')
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    outputs:
+      status: ${{ steps.h.outputs.status }}
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      CRITICAL_STACKS: ${{ needs.prepare.outputs.critical_stacks }}
+    steps:
+      - name: Health check critical stacks
+        id: h
+        run: |
+          set -euo pipefail
+          failed=()
+          for stack in $(echo "$CRITICAL_STACKS" | jq -r '.[]'); do
+            cd "$LIVE_REPO_PATH/$stack"
+            services=$(docker compose ps --format json | jq -s '.')
+            unhealthy=$(echo "$services" | jq -r \
+              '[.[] | select(.Health == "unhealthy" or (.Health == "" and .State != "running"))] | length')
+            if [[ "$unhealthy" -gt 0 ]]; then
+              failed+=("$stack")
+              echo "::error::Critical stack $stack has $unhealthy unhealthy services"
+              docker compose logs --tail 50
+            fi
+          done
+          if [[ ${#failed[@]} -gt 0 ]]; then
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "status=healthy" >> "$GITHUB_OUTPUT"
+
+  rollback:
+    needs: [prepare, deploy-existing, deploy-new, health-check]
+    if: |
+      always()
+      && needs.prepare.outputs.previous_sha != 'HEAD^'
+      && (needs.deploy-existing.result == 'failure'
+          || needs.deploy-new.result == 'failure'
+          || needs.health-check.result == 'failure')
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 15
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      PREVIOUS_SHA: ${{ needs.prepare.outputs.previous_sha }}
+    steps:
+      - name: Reset live tree to previous SHA
+        run: git -C "$LIVE_REPO_PATH" reset --hard "$PREVIOUS_SHA"
+
+      - name: Redeploy stacks at previous SHA
+        run: |
+          set -euo pipefail
+          for stack_dir in "$LIVE_REPO_PATH"/*/; do
+            [[ -f "$stack_dir/compose.yaml" ]] || continue
+            cd "$stack_dir"
+            docker compose pull || true
+            docker compose up -d --wait || echo "::warning::rollback up failed for $stack_dir"
+          done
+
+  cleanup-failed-new:
+    needs: [prepare, deploy-new]
+    if: always() && needs.deploy-new.result == 'failure'
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      NEW_STACKS: ${{ needs.prepare.outputs.new_stacks }}
+    steps:
+      - name: Tear down failed new stacks
+        run: |
+          set -euo pipefail
+          for stack in $(echo "$NEW_STACKS" | jq -r '.[]'); do
+            cd "$LIVE_REPO_PATH/$stack" 2>/dev/null || continue
+            docker compose down || true
+          done
+
+  notify:
+    name: Discord Notification
+    needs:
+      - prepare
+      - teardown-removed
+      - update-tree
+      - deploy-dockge
+      - deploy-existing
+      - deploy-new
+      - health-check
+      - rollback
+    if: always()
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    steps:
+      - name: Configure 1Password Service Account
+        uses: 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
+        with:
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Get commit message
+        id: commit-msg
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET_REF: ${{ inputs.target-ref }}
+        run: |
+          set -euo pipefail
+          COMMIT_MSG=$(gh api "repos/$GH_REPO/commits/$TARGET_REF" \
+            --jq '.commit.message // "No commit message available"' | head -1)
+          SHORT_SHA="${TARGET_REF:0:7}"
+          {
+            echo "message=$COMMIT_MSG"
+            echo "short-sha=$SHORT_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Compute notification status
+        id: status
+        env:
+          UPDATE_TREE_RESULT: ${{ needs.update-tree.result }}
+          TEARDOWN_RESULT: ${{ needs.teardown-removed.result }}
+          DEPLOY_DOCKGE_RESULT: ${{ needs.deploy-dockge.result }}
+          DEPLOY_EXISTING_RESULT: ${{ needs.deploy-existing.result }}
+          DEPLOY_NEW_RESULT: ${{ needs.deploy-new.result }}
+          HEALTH_RESULT: ${{ needs.health-check.result }}
+          HEALTH_STATUS: ${{ needs.health-check.outputs.status }}
+          ROLLBACK_RESULT: ${{ needs.rollback.result }}
+          HAS_REMOVED: ${{ needs.prepare.outputs.has_removed_stacks }}
+          HAS_EXISTING: ${{ needs.prepare.outputs.has_existing_stacks }}
+          HAS_NEW: ${{ needs.prepare.outputs.has_new_stacks }}
+          REMOVED_STACKS: ${{ needs.prepare.outputs.removed_stacks }}
+          FORCE_DEPLOY: ${{ inputs.force-deploy }}
+        run: |
+          set -euo pipefail
+
+          # Determine if any deployment work happened
+          deployment_needed="true"
+          if [[ "$HAS_REMOVED" != "true" && "$HAS_EXISTING" != "true" && "$HAS_NEW" != "true" ]]; then
+            deployment_needed="false"
+          fi
+
+          # Determine deploy phase aggregate status
+          deploy_status="success"
+          if [[ "$DEPLOY_EXISTING_RESULT" == "failure" || "$DEPLOY_NEW_RESULT" == "failure" \
+                || "$DEPLOY_DOCKGE_RESULT" == "failure" || "$UPDATE_TREE_RESULT" == "failure" \
+                || "$TEARDOWN_RESULT" == "failure" ]]; then
+            deploy_status="failure"
+          fi
+
+          # Health status (default to success if skipped/empty)
+          health_status="${HEALTH_STATUS:-}"
+          if [[ -z "$health_status" ]]; then
+            if [[ "$HEALTH_RESULT" == "success" || "$HEALTH_RESULT" == "skipped" ]]; then
+              health_status="success"
+            else
+              health_status="failure"
+            fi
+          fi
+
+          rollback_status="$ROLLBACK_RESULT"
+
+          # Final overall status
+          if [[ "$deployment_needed" == "false" ]]; then
+            overall="no-changes"
+            title_suffix="No Changes"
+            description="📋 **Repository already at target commit**"
+            color="7105644"   # 0x6c757d gray
+          elif [[ "$deploy_status" == "success" && "$health_status" == "success" ]]; then
+            overall="success"
+            if [[ "$FORCE_DEPLOY" == "true" ]]; then
+              description="🔄 **Force deployment completed successfully**"
+            else
+              description="✅ **Deployment completed successfully**"
+            fi
+            title_suffix="Deployed"
+            color="2664261"   # 0x28a745 green
+          elif [[ "$rollback_status" == "success" ]]; then
+            overall="rolled-back"
+            title_suffix="Rolled Back"
+            description="🔄 **Deployment failed but rolled back successfully**"
+            color="16763904"  # 0xffc107 yellow
+          else
+            overall="failure"
+            title_suffix="Failed"
+            description="❌ **Deployment failed**"
+            color="14431557"  # 0xdc3545 red
+          fi
+
+          {
+            echo "deployment_needed=$deployment_needed"
+            echo "deploy_status=$deploy_status"
+            echo "health_status=$health_status"
+            echo "rollback_status=$rollback_status"
+            echo "overall=$overall"
+            echo "title_suffix=$title_suffix"
+            echo "description<<EOF"
+            echo "$description"
+            echo "EOF"
+            echo "color=$color"
+          } >> "$GITHUB_OUTPUT"
+
+          # Pipeline status line
+          deploy_icon="✅"; [[ "$deploy_status" != "success" ]] && deploy_icon="❌"
+          health_icon="✅"
+          if [[ "$HEALTH_RESULT" == "skipped" ]]; then
+            health_icon="⏭️"
+          elif [[ "$health_status" != "success" ]]; then
+            health_icon="❌"
+          fi
+          rollback_line=""
+          if [[ "$rollback_status" != "skipped" ]]; then
+            rb_icon="✅"; [[ "$rollback_status" != "success" ]] && rb_icon="❌"
+            rollback_line=" → $rb_icon Rollback"
+          fi
+          pipeline="$deploy_icon Deploy → $health_icon Health$rollback_line"
+          {
+            echo "pipeline<<EOF"
+            echo "$pipeline"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          # Removed stacks line
+          removed_line=""
+          if [[ "$HAS_REMOVED" == "true" ]]; then
+            removed_names=$(echo "$REMOVED_STACKS" | jq -r '. | join(", ")' 2>/dev/null || echo "")
+            if [[ -n "$removed_names" ]]; then
+              removed_line="🗑️ **Removed stacks:** $removed_names"
+            fi
+          fi
+          {
+            echo "removed_line<<EOF"
+            echo "$removed_line"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Load Discord webhook and user ID
+        id: op-load-discord
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
+        with:
+          unset-previous: true
+        env:
+          DISCORD_WEBHOOK: ${{ inputs.webhook-url }}
+          DISCORD_USER_ID: ${{ inputs.discord-user-id != '' && inputs.discord-user-id || 'SKIP' }}
+
+      - name: Send Discord notification
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708  # v1.16.0
+        with:
+          webhook: ${{ steps.op-load-discord.outputs.DISCORD_WEBHOOK }}
+          content: ${{ (steps.status.outputs.overall == 'failure' || steps.status.outputs.overall == 'rolled-back') && inputs.discord-user-id != '' && steps.op-load-discord.outputs.DISCORD_USER_ID != 'SKIP' && format('<@{0}>', steps.op-load-discord.outputs.DISCORD_USER_ID) || '' }}
+          status: ${{ (steps.status.outputs.overall == 'success' || steps.status.outputs.overall == 'no-changes') && 'success' || 'failure' }}
+          title: "🚀 ${{ inputs.repo-name }} • ${{ steps.status.outputs.title_suffix }}"
+          description: |
+            ${{ steps.status.outputs.description }}
+
+            ${{ steps.status.outputs.removed_line }}
+
+            ${{ steps.status.outputs.deployment_needed == 'true' && format('**🔄 Pipeline Status**
+            {0}', steps.status.outputs.pipeline) || '' }}
+
+            ${{ github.event_name == 'workflow_dispatch' && '🔧 **Triggered manually**' || format('📝 **Commit:** [`{0}`](https://github.com/{1}/commit/{2}) {3}', steps.commit-msg.outputs.short-sha, github.repository, inputs.target-ref, steps.commit-msg.outputs.message) }}
+          color: ${{ steps.status.outputs.color }}
+          username: "Compose Deploy"
+          avatar_url: "https://cdn-icons-png.flaticon.com/512/919/919853.png"
+
+      - name: Unload Discord webhook
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
+        with:
+          unset-previous: true

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -79,15 +79,21 @@ jobs:
           LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
         run: |
           set -euo pipefail
-          CURRENT_SHA=$(git -C "$LIVE_REPO_PATH" rev-parse HEAD 2>/dev/null || echo "")
+
+          if [[ ! -d "$LIVE_REPO_PATH/.git" ]]; then
+            echo "❌ LIVE_REPO_PATH '$LIVE_REPO_PATH' is not a git repository (no .git directory found)" >&2
+            echo "❌ Verify the runner host has the repo cloned at this path and ownership matches the runner user." >&2
+            exit 1
+          fi
+
+          CURRENT_SHA=$(git -C "$LIVE_REPO_PATH" rev-parse HEAD)
           if [[ "$CURRENT_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; then
             echo "previous_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
             echo "has_previous_sha=true" >> "$GITHUB_OUTPUT"
             echo "✅ previous_sha=$CURRENT_SHA"
           else
-            echo "previous_sha=HEAD^" >> "$GITHUB_OUTPUT"
-            echo "has_previous_sha=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️  Live tree HEAD unreadable — using HEAD^ as fallback"
+            echo "❌ Live tree HEAD is not a valid 40-character commit SHA: '$CURRENT_SHA'" >&2
+            exit 1
           fi
 
       - name: Get changed files (for removal detection)
@@ -404,6 +410,7 @@ jobs:
         id: status
         env:
           UPDATE_TREE_RESULT: ${{ needs.update-tree.result }}
+          UPDATE_TREE_SKIPPED: ${{ needs.update-tree.outputs.skipped }}
           TEARDOWN_RESULT: ${{ needs.teardown-removed.result }}
           DEPLOY_DOCKGE_RESULT: ${{ needs.deploy-dockge.result }}
           DEPLOY_EXISTING_RESULT: ${{ needs.deploy-existing.result }}
@@ -422,6 +429,8 @@ jobs:
           # Determine if any deployment work happened
           deployment_needed="true"
           if [[ "$HAS_REMOVED" != "true" && "$HAS_EXISTING" != "true" && "$HAS_NEW" != "true" ]]; then
+            deployment_needed="false"
+          elif [[ "${UPDATE_TREE_RESULT:-}" == "success" && "${UPDATE_TREE_SKIPPED:-}" == "true" && "${FORCE_DEPLOY:-}" != "true" ]]; then
             deployment_needed="false"
           fi
 

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -106,7 +106,7 @@ jobs:
           LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
           PREVIOUS_SHA: ${{ steps.previous-sha.outputs.previous_sha }}
           TARGET_REF: ${{ inputs.target-ref }}
-          REMOVED_FILES: ${{ steps.changed-files.outputs.deleted_files }}
+          REMOVED_FILES: ${{ steps.changed-files.outputs.deleted_files != '' && steps.changed-files.outputs.deleted_files || '[]' }}
         run: |
           ./.compose-workflow/scripts/deployment/detect-stack-changes.sh \
             --mode local \
@@ -273,12 +273,13 @@ jobs:
       status: ${{ steps.h.outputs.status }}
     env:
       LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
-      CRITICAL_STACKS: ${{ needs.prepare.outputs.critical_stacks }}
+      CRITICAL_STACKS: ${{ inputs.auto-detect-critical && needs.prepare.outputs.critical_stacks || inputs.critical-services }}
     steps:
       - name: Health check critical stacks
         id: h
         run: |
           set -euo pipefail
+          CRITICAL_STACKS="${CRITICAL_STACKS:-[]}"
           failed=()
           for stack in $(echo "$CRITICAL_STACKS" | jq -r '.[]'); do
             cd "$LIVE_REPO_PATH/$stack"

--- a/docs/superpowers/plans/2026-04-29-self-hosted-deploy-runner-pilot.md
+++ b/docs/superpowers/plans/2026-04-29-self-hosted-deploy-runner-pilot.md
@@ -1,0 +1,960 @@
+# Self-Hosted Deploy Runner Pilot — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pilot a self-hosted GitHub Actions runner on the `docker-piwine-office` deploy host, eliminating Tailscale + SSH from the deploy path while preserving all current behaviors (stack categorization, critical detection, rollback, dockge handling, Discord notifications).
+
+**Architecture:** A new reusable workflow `deploy-local.yml` runs on `[self-hosted, piwine-office]`. It is **workflow-native, not script-driven**: the deploy/health/rollback/cleanup operations that today live inside SSH heredocs (`deploy-stacks.sh`, `health-check.sh`, `rollback-stacks.sh`, `cleanup-stack.sh`) are inlined as workflow steps, with per-stack work expressed as a `strategy.matrix` job for native parallelism and per-stack visibility in the Actions UI. The two genuinely-pure-logic scripts (`detect-stack-changes.sh`, `detect-critical-stacks.sh`) are reused. `detect-stack-changes.sh` gets one focused refactor to add `--mode local` (its only SSH-coupled siblings stay untouched). The existing `deploy.yml` (SSH-based) is unchanged during the pilot.
+
+**Tech Stack:** GitHub Actions (reusable workflows, matrix strategy), bash, Docker Compose, 1Password Connect, systemd (for the runner service).
+
+**Spec:** `docs/superpowers/specs/2026-04-29-self-hosted-deploy-runner-pilot-design.md`
+
+---
+
+## File Structure
+
+**Created in `compose-workflow`:**
+- `.github/workflows/deploy-local.yml` — new reusable workflow
+
+**Modified in `compose-workflow`:**
+- `scripts/deployment/detect-stack-changes.sh` — add `--mode local` (the only script touched)
+
+**Untouched in `compose-workflow`:**
+- `deploy-stacks.sh`, `health-check.sh`, `rollback-stacks.sh`, `cleanup-stack.sh` — remain SSH-based, used by `deploy.yml` for piwine and zendc until they migrate
+- `detect-critical-stacks.sh` — already mode-agnostic, called as-is
+- `deploy.yml` — unchanged
+
+**Created/modified in `docker-piwine-office`:**
+- `.github/workflows/deploy-local.yml` — manual pilot caller (Task 4.1)
+- `.github/workflows/deploy.yml` — switched to invoke the new reusable workflow (Task 4.3)
+
+**Out-of-band (host setup, not version-controlled):**
+- `/home/deploy/actions-runner/` — runner installation
+- systemd service `actions.runner.owine-docker-piwine-office.<name>.service`
+- Ownership transfer of `/opt/compose` and `/opt/dockge` to `deploy:deploy`
+
+---
+
+## Phase 1 — Refactor `detect-stack-changes.sh` for local execution
+
+This is the single script that must change. It has 6 `ssh_retry "ssh ... 'cmd'"` calls; in local mode each becomes a direct `bash -c 'cmd'` (or equivalent) running against the `_work/` checkout. The other four heredoc-driven scripts are not touched — their logic moves inline in Phase 2.
+
+### Task 1.1: Add `--mode local` to `detect-stack-changes.sh`
+
+**Files:**
+- Modify: `scripts/deployment/detect-stack-changes.sh`
+
+- [ ] **Step 1: Add `--mode` argument and validate**
+
+```bash
+# Near other defaults
+MODE="ssh"
+
+# In argument parser
+--mode)
+  MODE="$2"
+  shift 2
+  ;;
+
+# After parsing
+if [[ "$MODE" != "ssh" && "$MODE" != "local" ]]; then
+  echo "❌ --mode must be 'ssh' or 'local', got: $MODE"
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Make `--ssh-user` and `--ssh-host` conditional on mode**
+
+Move the existing `require_var SSH_USER` / `require_var SSH_HOST` (lines ~61-62) inside an `if [[ "$MODE" == "ssh" ]]; then ... fi` guard. Add a `--live-repo-path` argument required when `MODE=local` (default unset; error in `local` mode if missing).
+
+- [ ] **Step 3: Introduce a `run_remote` wrapper**
+
+Near the top of the script, after sourcing helpers:
+```bash
+run_remote() {
+  # Usage: echo "<bash script>" | run_remote arg1 arg2 ...
+  # Reads script from stdin, runs with positional args.
+  local args=("$@")
+  if [[ "$MODE" == "local" ]]; then
+    LIVE_REPO_PATH="$LIVE_REPO_PATH" bash -s "${args[@]}"
+  else
+    ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST /bin/bash -s ${args[*]@Q}"
+  fi
+}
+```
+
+- [ ] **Step 4: Replace each of the 6 SSH call sites**
+
+For each line that currently reads:
+```bash
+echo "$detect_script" | ssh_retry 3 5 "ssh ... $SSH_USER@$SSH_HOST /bin/bash -s \"$arg1\" \"$arg2\""
+```
+Change to:
+```bash
+echo "$detect_script" | run_remote "$arg1" "$arg2"
+```
+
+Inside each `$detect_script` heredoc body, change any `cd /opt/compose` to `cd "$LIVE_REPO_PATH"` (or pass the path as a positional arg to make the script self-contained). The heredoc bodies should already be agnostic to whether they run locally or remotely — they're plain bash.
+
+- [ ] **Step 5: Run `shellcheck`**
+
+```bash
+shellcheck scripts/deployment/detect-stack-changes.sh
+```
+Expected: no new warnings.
+
+- [ ] **Step 6: Local smoke test**
+
+Pick a real commit pair on this repo (e.g., `git rev-parse HEAD` and `git rev-parse HEAD~1`) and run:
+```bash
+LIVE_REPO_PATH=/Users/owine/Git/Compose/compose-workflow \
+./scripts/deployment/detect-stack-changes.sh \
+  --mode local \
+  --previous-sha $(git rev-parse HEAD~1) \
+  --target-ref $(git rev-parse HEAD) \
+  --live-repo-path /Users/owine/Git/Compose/compose-workflow \
+  --removed-files '[]'
+```
+Expected: outputs `removed_stacks=[]`, `existing_stacks=[]`, `new_stacks=[]` (or actual values if there are stacks in this repo — there aren't, since `compose-workflow` itself has no compose stacks). On a real repo with stacks (e.g., a clone of `docker-piwine-office`), expect non-empty arrays. Crucially: **no SSH attempt, no `command not found: ssh`**.
+
+- [ ] **Step 7: Backward-compat verification**
+
+Run the existing `deploy.yml` workflow against `docker-piwine` (push to a throwaway branch and trigger via `workflow_dispatch`, or wait for the next Renovate PR merge). Expected: green deploy. The default `MODE=ssh` keeps current behavior.
+
+- [ ] **Step 8: Open PR for Phase 1 to `compose-workflow`**
+
+```bash
+git add scripts/deployment/detect-stack-changes.sh
+git commit -m "feat(detect-stack-changes): add --mode local for self-hosted runner support"
+git push
+gh pr create --title "feat(detect-stack-changes): add --mode local for self-hosted runner" \
+             --body "Adds a --mode local flag to detect-stack-changes.sh for use by the upcoming deploy-local.yml workflow. Default mode remains ssh; existing deploy.yml callers are unaffected."
+```
+
+Wait for a green deploy on `docker-piwine` after merge before proceeding to Phase 2.
+
+---
+
+## Phase 2 — Build `deploy-local.yml` (`compose-workflow` repo)
+
+Multi-job workflow with native parallelism. Job graph:
+
+```
+prepare → teardown-removed → update-tree → deploy-dockge ─┐
+                                          └→ deploy-existing (matrix) → deploy-new (matrix) → health → [rollback?] → notify
+```
+
+All jobs run on `[self-hosted, piwine-office]`. The matrix jobs give per-stack visibility in the Actions UI and use GitHub-native parallelism instead of bash PID tracking.
+
+### Task 2.1: Workflow skeleton with inputs and the `prepare` job
+
+**Files:**
+- Create: `.github/workflows/deploy-local.yml`
+
+- [ ] **Step 1: Write the skeleton with `prepare` job**
+
+```yaml
+---
+name: Deploy (Local Self-Hosted)
+
+on:
+  workflow_call:
+    inputs:
+      live-repo-path:
+        description: "Absolute path to the live compose tree on the runner host"
+        required: true
+        type: string
+      live-dockge-path:
+        description: "Absolute path to dockge's compose tree (when has-dockge=true)"
+        required: false
+        type: string
+        default: /opt/dockge
+      repo-name:
+        required: true
+        type: string
+      webhook-url:
+        required: true
+        type: string
+      discord-user-id:
+        required: true
+        type: string
+      target-ref:
+        required: true
+        type: string
+      has-dockge:
+        type: boolean
+        default: false
+      force-deploy:
+        type: boolean
+        default: false
+      auto-detect-critical:
+        type: boolean
+        default: true
+      critical-services:
+        type: string
+        default: '[]'
+      image-pull-timeout:
+        type: number
+        default: 600
+      service-startup-timeout:
+        type: number
+        default: 300
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    outputs:
+      previous_sha: ${{ steps.previous-sha.outputs.previous_sha }}
+      removed_stacks: ${{ steps.detect-changes.outputs.removed_stacks }}
+      existing_stacks: ${{ steps.detect-changes.outputs.existing_stacks }}
+      new_stacks: ${{ steps.detect-changes.outputs.new_stacks }}
+      has_removed_stacks: ${{ steps.detect-changes.outputs.has_removed_stacks }}
+      has_existing_stacks: ${{ steps.detect-changes.outputs.has_existing_stacks }}
+      has_new_stacks: ${{ steps.detect-changes.outputs.has_new_stacks }}
+      critical_stacks: ${{ steps.detect-critical.outputs.critical_stacks }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.target-ref }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: owine/compose-workflow
+          ref: main
+          path: .compose-workflow
+
+      - name: Capture previous deployment SHA from live tree
+        id: previous-sha
+        env:
+          LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+        run: |
+          set -euo pipefail
+          CURRENT_SHA=$(git -C "$LIVE_REPO_PATH" rev-parse HEAD 2>/dev/null || echo "")
+          if [[ "$CURRENT_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; then
+            echo "previous_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+            echo "✅ previous_sha=$CURRENT_SHA"
+          else
+            echo "previous_sha=HEAD^" >> "$GITHUB_OUTPUT"
+            echo "⚠️  Live tree HEAD unreadable — using HEAD^ as fallback"
+          fi
+
+      - name: Get changed files (for removal detection)
+        id: changed-files
+        if: steps.previous-sha.outputs.previous_sha != inputs.target-ref
+        continue-on-error: true
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
+        with:
+          json: true
+          sha: ${{ inputs.target-ref }}
+          base_sha: ${{ steps.previous-sha.outputs.previous_sha }}
+
+      - name: Detect stack changes
+        id: detect-changes
+        env:
+          LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+        run: |
+          ./.compose-workflow/scripts/deployment/detect-stack-changes.sh \
+            --mode local \
+            --previous-sha "${{ steps.previous-sha.outputs.previous_sha }}" \
+            --target-ref "${{ inputs.target-ref }}" \
+            --live-repo-path "$LIVE_REPO_PATH" \
+            --removed-files '${{ steps.changed-files.outputs.deleted_files }}'
+
+      - name: Detect critical stacks
+        id: detect-critical
+        if: inputs.auto-detect-critical
+        run: ./.compose-workflow/scripts/deployment/detect-critical-stacks.sh
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+actionlint .github/workflows/deploy-local.yml
+yamllint --strict .github/workflows/deploy-local.yml
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy-local.yml
+git commit -m "feat(deploy-local): add prepare job — capture SHA and detect changes"
+```
+
+### Task 2.2: `teardown-removed` job
+
+**Files:**
+- Modify: `.github/workflows/deploy-local.yml`
+
+- [ ] **Step 1: Append the job**
+
+```yaml
+  teardown-removed:
+    needs: prepare
+    if: needs.prepare.outputs.has_removed_stacks == 'true'
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 10
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      REMOVED_STACKS: ${{ needs.prepare.outputs.removed_stacks }}
+    steps:
+      - name: Stop removed stacks (uses pre-reset compose files)
+        run: |
+          set -euo pipefail
+          for stack in $(echo "$REMOVED_STACKS" | jq -r '.[]'); do
+            compose_file="$LIVE_REPO_PATH/$stack/compose.yaml"
+            if [[ -f "$compose_file" ]]; then
+              echo "🛑 Stopping $stack"
+              docker compose -f "$compose_file" down || echo "::warning::down failed for $stack"
+            else
+              echo "::warning::compose file missing for removed stack $stack"
+            fi
+          done
+
+      - name: Discord notify removed stacks
+        env:
+          DISCORD_WEBHOOK_URL: ${{ inputs.webhook-url }}  # NOTE: 1P resolution happens via load-secrets-action; see Task 2.6
+        run: |
+          # Placeholder — full Discord payload added in Task 2.6 alongside other notifications
+          echo "🔔 Removed: $REMOVED_STACKS"
+```
+
+(The Discord notification is stubbed here; the full implementation is consolidated in Task 2.6 to keep secret loading in one place.)
+
+- [ ] **Step 2: Lint and commit**
+
+```bash
+actionlint .github/workflows/deploy-local.yml
+yamllint --strict .github/workflows/deploy-local.yml
+git add .github/workflows/deploy-local.yml
+git commit -m "feat(deploy-local): add teardown-removed job"
+```
+
+### Task 2.3: `update-tree` job — point of no return
+
+**Files:**
+- Modify: `.github/workflows/deploy-local.yml`
+
+- [ ] **Step 1: Append the job**
+
+```yaml
+  update-tree:
+    needs: [prepare, teardown-removed]
+    # Run if teardown-removed succeeded OR was skipped (no removed stacks)
+    if: |
+      always() && needs.prepare.result == 'success'
+      && (needs.teardown-removed.result == 'success' || needs.teardown-removed.result == 'skipped')
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      TARGET_REF: ${{ inputs.target-ref }}
+    steps:
+      - name: Skip if already at target SHA (and not forced)
+        id: gate
+        run: |
+          set -euo pipefail
+          CURRENT_SHA=$(git -C "$LIVE_REPO_PATH" rev-parse HEAD)
+          if [[ "$CURRENT_SHA" == "$TARGET_REF" && "${{ inputs.force-deploy }}" != "true" ]]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  Already at $TARGET_REF; skipping update"
+          else
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update live tree
+        if: steps.gate.outputs.skipped == 'false'
+        run: |
+          set -euo pipefail
+          git -C "$LIVE_REPO_PATH" fetch
+          git -C "$LIVE_REPO_PATH" reset --hard "$TARGET_REF"
+          echo "✅ /opt/compose now at $TARGET_REF"
+```
+
+- [ ] **Step 2: Lint and commit**
+
+```bash
+actionlint .github/workflows/deploy-local.yml
+yamllint --strict .github/workflows/deploy-local.yml
+git add .github/workflows/deploy-local.yml
+git commit -m "feat(deploy-local): add update-tree job"
+```
+
+### Task 2.4: `deploy-dockge`, `deploy-existing`, `deploy-new` matrix jobs
+
+**Files:**
+- Modify: `.github/workflows/deploy-local.yml`
+
+- [ ] **Step 1: Append `deploy-dockge`**
+
+```yaml
+  deploy-dockge:
+    needs: [prepare, update-tree]
+    if: |
+      always() && needs.update-tree.result == 'success'
+      && inputs.has-dockge
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 10
+    env:
+      DOCKGE_PATH: ${{ inputs.live-dockge-path }}
+      IMAGE_PULL_TIMEOUT: ${{ inputs.image-pull-timeout }}
+      SERVICE_STARTUP_TIMEOUT: ${{ inputs.service-startup-timeout }}
+    steps:
+      - name: Pull and start dockge
+        run: |
+          set -euo pipefail
+          cd "$DOCKGE_PATH"
+          timeout "$IMAGE_PULL_TIMEOUT" docker compose pull
+          timeout "$SERVICE_STARTUP_TIMEOUT" docker compose up -d --wait
+```
+
+- [ ] **Step 2: Append `deploy-existing` matrix job**
+
+```yaml
+  deploy-existing:
+    needs: [prepare, update-tree, deploy-dockge]
+    if: |
+      always()
+      && needs.update-tree.result == 'success'
+      && (needs.deploy-dockge.result == 'success' || needs.deploy-dockge.result == 'skipped')
+      && needs.prepare.outputs.has_existing_stacks == 'true'
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        stack: ${{ fromJSON(needs.prepare.outputs.existing_stacks) }}
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      IMAGE_PULL_TIMEOUT: ${{ inputs.image-pull-timeout }}
+      SERVICE_STARTUP_TIMEOUT: ${{ inputs.service-startup-timeout }}
+    steps:
+      - name: Load 1Password env for stack
+        # Most stacks read compose.env via docker compose; if any stack needs op
+        # references resolved at deploy time, do it here. For now, no-op.
+        run: echo "ℹ️  Stack ${{ matrix.stack }} uses compose.env at runtime"
+
+      - name: Pull and deploy ${{ matrix.stack }}
+        run: |
+          set -euo pipefail
+          cd "$LIVE_REPO_PATH/${{ matrix.stack }}"
+          timeout "$IMAGE_PULL_TIMEOUT" docker compose pull
+          timeout "$SERVICE_STARTUP_TIMEOUT" docker compose up -d --wait
+```
+
+- [ ] **Step 3: Append `deploy-new` matrix job (depends on existing succeeding)**
+
+```yaml
+  deploy-new:
+    needs: [prepare, update-tree, deploy-existing]
+    if: |
+      always()
+      && needs.update-tree.result == 'success'
+      && (needs.deploy-existing.result == 'success' || needs.deploy-existing.result == 'skipped')
+      && needs.prepare.outputs.has_new_stacks == 'true'
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        stack: ${{ fromJSON(needs.prepare.outputs.new_stacks) }}
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      IMAGE_PULL_TIMEOUT: ${{ inputs.image-pull-timeout }}
+      SERVICE_STARTUP_TIMEOUT: ${{ inputs.service-startup-timeout }}
+    steps:
+      - name: Pull and deploy ${{ matrix.stack }}
+        run: |
+          set -euo pipefail
+          cd "$LIVE_REPO_PATH/${{ matrix.stack }}"
+          timeout "$IMAGE_PULL_TIMEOUT" docker compose pull
+          timeout "$SERVICE_STARTUP_TIMEOUT" docker compose up -d --wait
+```
+
+- [ ] **Step 4: Lint and commit**
+
+```bash
+actionlint .github/workflows/deploy-local.yml
+yamllint --strict .github/workflows/deploy-local.yml
+git add .github/workflows/deploy-local.yml
+git commit -m "feat(deploy-local): add deploy-dockge and per-stack matrix jobs"
+```
+
+### Task 2.5: `health-check` and `rollback` jobs
+
+**Files:**
+- Modify: `.github/workflows/deploy-local.yml`
+
+`health-check` validates that critical stacks reached `healthy` per `docker compose ps`. Logic ported from `health-check.sh`'s heredoc body, simplified: per-stack `docker compose ps --format json`, parse `Health` field, error if any critical stack is not `healthy` (or `running` for stacks without healthchecks).
+
+- [ ] **Step 1: Append `health-check`**
+
+```yaml
+  health-check:
+    needs: [prepare, deploy-existing, deploy-new]
+    if: |
+      always()
+      && (needs.deploy-existing.result == 'success' || needs.deploy-existing.result == 'skipped')
+      && (needs.deploy-new.result == 'success' || needs.deploy-new.result == 'skipped')
+      && (needs.deploy-existing.result != 'skipped' || needs.deploy-new.result != 'skipped')
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    outputs:
+      status: ${{ steps.h.outputs.status }}
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      CRITICAL_STACKS: ${{ needs.prepare.outputs.critical_stacks }}
+    steps:
+      - name: Health check critical stacks
+        id: h
+        run: |
+          set -euo pipefail
+          failed=()
+          for stack in $(echo "$CRITICAL_STACKS" | jq -r '.[]'); do
+            cd "$LIVE_REPO_PATH/$stack"
+            services=$(docker compose ps --format json | jq -s '.')
+            unhealthy=$(echo "$services" | jq -r \
+              '[.[] | select(.Health == "unhealthy" or (.Health == "" and .State != "running"))] | length')
+            if [[ "$unhealthy" -gt 0 ]]; then
+              failed+=("$stack")
+              echo "::error::Critical stack $stack has $unhealthy unhealthy services"
+              docker compose logs --tail 50
+            fi
+          done
+          if [[ ${#failed[@]} -gt 0 ]]; then
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "status=healthy" >> "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 2: Append `rollback`**
+
+```yaml
+  rollback:
+    needs: [prepare, deploy-existing, deploy-new, health-check]
+    if: |
+      always()
+      && needs.prepare.outputs.previous_sha != 'HEAD^'
+      && (needs.deploy-existing.result == 'failure'
+          || needs.deploy-new.result == 'failure'
+          || needs.health-check.result == 'failure')
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 15
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      PREVIOUS_SHA: ${{ needs.prepare.outputs.previous_sha }}
+    steps:
+      - name: Reset live tree to previous SHA
+        run: git -C "$LIVE_REPO_PATH" reset --hard "$PREVIOUS_SHA"
+
+      - name: Redeploy stacks at previous SHA
+        run: |
+          set -euo pipefail
+          for stack_dir in "$LIVE_REPO_PATH"/*/; do
+            [[ -f "$stack_dir/compose.yaml" ]] || continue
+            cd "$stack_dir"
+            docker compose pull || true
+            docker compose up -d --wait || echo "::warning::rollback up failed for $stack_dir"
+          done
+
+  cleanup-failed-new:
+    needs: [prepare, deploy-new]
+    if: always() && needs.deploy-new.result == 'failure'
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    env:
+      LIVE_REPO_PATH: ${{ inputs.live-repo-path }}
+      NEW_STACKS: ${{ needs.prepare.outputs.new_stacks }}
+    steps:
+      - name: Tear down failed new stacks
+        run: |
+          set -euo pipefail
+          for stack in $(echo "$NEW_STACKS" | jq -r '.[]'); do
+            cd "$LIVE_REPO_PATH/$stack" 2>/dev/null || continue
+            docker compose down || true
+          done
+```
+
+- [ ] **Step 3: Lint and commit**
+
+```bash
+actionlint .github/workflows/deploy-local.yml
+yamllint --strict .github/workflows/deploy-local.yml
+git add .github/workflows/deploy-local.yml
+git commit -m "feat(deploy-local): add health-check, rollback, cleanup-failed-new jobs"
+```
+
+### Task 2.6: `notify` job (single source of Discord truth)
+
+**Files:**
+- Modify: `.github/workflows/deploy-local.yml`
+
+Consolidate Discord notifications into one job that runs at the end and reports: success / partial-failure-rolled-back / partial-failure-no-rollback / removed-stacks-summary. Loads 1Password secrets here.
+
+- [ ] **Step 1: Append the job**
+
+```yaml
+  notify:
+    needs:
+      - prepare
+      - teardown-removed
+      - update-tree
+      - deploy-dockge
+      - deploy-existing
+      - deploy-new
+      - health-check
+      - rollback
+    if: always()
+    runs-on: [self-hosted, piwine-office]
+    timeout-minutes: 5
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    steps:
+      - uses: 1password/load-secrets-action@v3
+        id: op
+        with:
+          export-env: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ inputs.webhook-url }}
+          DISCORD_USER_ID: ${{ inputs.discord-user-id }}
+
+      - name: Determine overall status and post notification
+        env:
+          REPO_NAME: ${{ inputs.repo-name }}
+          TARGET_REF: ${{ inputs.target-ref }}
+          REMOVED_STACKS: ${{ needs.prepare.outputs.removed_stacks }}
+          HEALTH_STATUS: ${{ needs.health-check.outputs.status }}
+        run: |
+          set -euo pipefail
+          # Compose payload based on job results; mention user on failure.
+          # Reuse jq-based payload pattern from existing deploy.yml.
+          # (Full implementation: copy the success/failure embed templates from
+          # current deploy.yml lines ~830-960, swapping field values for these
+          # job results.)
+          # TODO: paste Discord payload here from existing workflow's notify step.
+          echo "Will post Discord embed for $REPO_NAME @ $TARGET_REF"
+```
+
+- [ ] **Step 2: Port the Discord payload from the existing `deploy.yml`**
+
+Copy the success and failure embed JSON templates from `deploy.yml`'s notify step. Adapt field references to use `needs.<job>.result` outputs from this workflow. Do not recreate from scratch — keep payloads identical to today's so the channel messages look the same.
+
+- [ ] **Step 3: Lint and commit**
+
+```bash
+actionlint .github/workflows/deploy-local.yml
+yamllint --strict .github/workflows/deploy-local.yml
+git add .github/workflows/deploy-local.yml
+git commit -m "feat(deploy-local): add notify job with Discord payload"
+```
+
+### Task 2.7: Cross-check against current `deploy.yml` and open PR
+
+- [ ] **Step 1: Step-list diff**
+
+```bash
+diff <(grep -E "^\s*- name:" .github/workflows/deploy.yml | sort -u) \
+     <(grep -E "^\s*- name:" .github/workflows/deploy-local.yml | sort -u)
+```
+Expected differences in `deploy-local.yml`: missing all Tailscale, SSH known-hosts, SSH multiplexing, `Determine previous deployment SHA`, `Store current deployment for rollback` steps. Confirm no business-logic step is missing: deploy existing, deploy new, dockge, health, rollback, cleanup-failed-new, notify, removed notify all present.
+
+- [ ] **Step 2: Open PR for Phase 2**
+
+```bash
+gh pr create --title "feat(workflows): add deploy-local.yml for self-hosted runner deploys" \
+             --body "Workflow-native rewrite of the deploy logic for self-hosted runners. Each stack runs in its own matrix job; health/rollback/cleanup steps are inline (no SSH heredoc baggage). Reuses detect-stack-changes.sh (--mode local) and detect-critical-stacks.sh from Phase 1. Existing deploy.yml unchanged. Cannot be exercised end-to-end until Phase 3 (host setup) and Phase 4 (caller wiring) land."
+```
+
+Merge after maintainer review of the workflow shape. The file is dormant until called.
+
+---
+
+## Phase 3 — Host Setup (out-of-band, human-admin)
+
+These steps run on the `docker-piwine-office` host as a human admin with sudo. They are not version-controlled. Capture in `~/Git/Compose/CLAUDE.md` or a private runbook for reproducibility on the next two hosts.
+
+### Task 3.1: Provision the deploy user
+
+- [ ] **Step 1: Create user, grant docker access**
+
+```bash
+sudo useradd -m -s /bin/bash deploy
+sudo usermod -aG docker deploy
+```
+
+- [ ] **Step 2: Verify docker access**
+
+```bash
+sudo -u deploy docker ps
+```
+Expected: lists running containers (or empty), no permission error.
+
+- [ ] **Step 3: Transfer ownership**
+
+```bash
+sudo chown -R deploy:deploy /opt/compose /opt/dockge
+```
+
+- [ ] **Step 4: Verify git operations as deploy**
+
+```bash
+sudo -u deploy git -C /opt/compose status
+sudo -u deploy git -C /opt/compose rev-parse HEAD
+sudo -u deploy git -C /opt/dockge status 2>/dev/null || echo "(dockge may not be a git repo — that's fine)"
+```
+Expected: clean status, valid SHA on `/opt/compose`. No `safe.directory` warnings.
+
+### Task 3.2: Install and register the runner
+
+- [ ] **Step 1: Get a registration token**
+
+`https://github.com/owine/docker-piwine-office/settings/actions/runners/new` → copy the registration token (1-hour validity).
+
+- [ ] **Step 2: Download and extract**
+
+```bash
+sudo -u deploy bash -c '
+  cd ~ && mkdir -p actions-runner && cd actions-runner
+  curl -o actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v<VERSION>/actions-runner-linux-arm64-<VERSION>.tar.gz
+  tar xzf actions-runner.tar.gz
+'
+```
+Pin `<VERSION>` to a specific stable release; record in the runbook.
+
+- [ ] **Step 3: Register**
+
+```bash
+sudo -u deploy bash -c '
+  cd ~/actions-runner
+  ./config.sh --url https://github.com/owine/docker-piwine-office \
+              --token <TOKEN> --labels piwine-office --unattended --replace
+'
+```
+
+- [ ] **Step 4: Install systemd service running as deploy**
+
+```bash
+cd /home/deploy/actions-runner
+sudo ./svc.sh install deploy
+sudo ./svc.sh start
+sudo ./svc.sh status
+```
+
+- [ ] **Step 5: Verify in GitHub UI**
+
+Settings → Actions → Runners → one online runner with labels `self-hosted, Linux, ARM64, piwine-office`.
+
+### Task 3.3: Smoke test — runner executes a trivial workflow
+
+- [ ] **Step 1: Add temporary smoke workflow to `docker-piwine-office`**
+
+`.github/workflows/runner-smoke.yml`:
+```yaml
+---
+name: Runner Smoke Test
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  smoke:
+    runs-on: [self-hosted, piwine-office]
+    steps:
+      - run: |
+          set -euo pipefail
+          echo "user: $(whoami)"
+          docker ps
+          git -C /opt/compose rev-parse HEAD
+          test -d /opt/dockge && echo "/opt/dockge OK"
+          jq --version
+          # Verify tools the new workflow depends on
+          command -v timeout
+          command -v docker
+```
+
+- [ ] **Step 2: Trigger and verify**
+
+`gh workflow run -R owine/docker-piwine-office runner-smoke.yml`
+
+Verify:
+- `whoami` → `deploy`
+- `docker ps` succeeds without sudo
+- `git -C /opt/compose rev-parse HEAD` returns a valid SHA
+- `/opt/dockge` exists
+- `jq`, `timeout`, `docker` are on PATH
+
+If `jq` is missing, `apt install jq` as root (one-time host-prep). Document in runbook.
+
+- [ ] **Step 3: Delete the smoke workflow**
+
+```bash
+git -C ~/Git/Compose/docker-piwine-office rm .github/workflows/runner-smoke.yml
+git -C ~/Git/Compose/docker-piwine-office commit -m "chore: remove runner smoke test"
+git -C ~/Git/Compose/docker-piwine-office push
+```
+
+---
+
+## Phase 4 — Caller Wiring (`docker-piwine-office`)
+
+### Task 4.1: Manual pilot caller
+
+**Files:**
+- Create: `.github/workflows/deploy-local.yml` in `docker-piwine-office`
+
+- [ ] **Step 1: Write caller**
+
+```yaml
+---
+name: Deploy (Local) — Manual Pilot
+
+on:
+  workflow_dispatch:
+    inputs:
+      target-ref:
+        description: "Git SHA to deploy (default: HEAD of main)"
+        required: false
+        default: ""
+      force-deploy:
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-piwine-office
+  cancel-in-progress: false
+
+jobs:
+  resolve-ref:
+    runs-on: ubuntu-24.04
+    outputs:
+      sha: ${{ steps.r.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: r
+        run: |
+          REF="${{ inputs.target-ref }}"
+          if [ -z "$REF" ]; then REF=$(git rev-parse HEAD); fi
+          echo "sha=$REF" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: resolve-ref
+    uses: owine/compose-workflow/.github/workflows/deploy-local.yml@main
+    secrets: inherit
+    with:
+      live-repo-path: /opt/compose
+      live-dockge-path: /opt/dockge
+      repo-name: docker-piwine-office
+      webhook-url: "op://Docker/discord-github-notifications/piwine_office_webhook_url"
+      discord-user-id: "op://Docker/discord-github-notifications/user_id"
+      target-ref: ${{ needs.resolve-ref.outputs.sha }}
+      has-dockge: true
+      force-deploy: ${{ inputs.force-deploy }}
+```
+
+Cross-check the 1Password references against the existing caller `deploy.yml` to avoid typos.
+
+- [ ] **Step 2: Lint, commit, push**
+
+```bash
+actionlint .github/workflows/deploy-local.yml
+yamllint --strict .github/workflows/deploy-local.yml
+git add .github/workflows/deploy-local.yml
+git commit -m "feat(deploy): add manual pilot caller for self-hosted runner"
+git push
+```
+
+### Task 4.2: End-to-end smoke test
+
+- [ ] **Step 1: Trigger with `force-deploy: true`**
+
+```bash
+gh workflow run -R owine/docker-piwine-office "Deploy (Local) — Manual Pilot" -f force-deploy=true
+```
+
+- [ ] **Step 2: Watch run**
+
+In Actions UI verify in order:
+- `prepare` job: `previous_sha` matches `git -C /opt/compose rev-parse HEAD` from the box (run that command in a separate terminal during the run to confirm)
+- `teardown-removed`: skipped (nothing removed in a no-op deploy)
+- `update-tree`: completes (`gate.skipped` may be true if force-deploy not set; with force, runs the reset)
+- `deploy-dockge`: runs and succeeds
+- `deploy-existing`: matrix runs `dozzle` and `portainer` in parallel; both green
+- `deploy-new`: skipped
+- `health-check`: green
+- `rollback`, `cleanup-failed-new`: skipped
+- `notify`: posts to the piwine-office Discord channel
+
+- [ ] **Step 3: Verify host state**
+
+```bash
+sudo -u deploy git -C /opt/compose rev-parse HEAD
+docker ps --filter "label=com.docker.compose.project" --format "{{.Names}} {{.Status}}"
+```
+Expected: SHA matches deployed; `dozzle`, `portainer`, and dockge containers all healthy.
+
+- [ ] **Step 4: If smoke fails, do not proceed**
+
+Diagnose against spec failure-modes table. Common pitfalls: 1Password token scope, `safe.directory` (ownership), missing `jq`/`timeout` on PATH, runner not picking up jobs (label mismatch). Fix in `compose-workflow`, push, re-run the manual pilot.
+
+### Task 4.3: Cutover
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml` in `docker-piwine-office`
+- Delete: `.github/workflows/deploy-local.yml` in `docker-piwine-office`
+
+- [ ] **Step 1: Repoint `deploy.yml` at the new reusable workflow**
+
+In `deploy.yml`, change the `uses:` from `owine/compose-workflow/.github/workflows/deploy.yml@main` to `owine/compose-workflow/.github/workflows/deploy-local.yml@main`. Update inputs to match Task 4.1 (add `live-repo-path`, `live-dockge-path`; drop any SSH-specific inputs that no longer exist).
+
+- [ ] **Step 2: Delete the now-redundant manual pilot caller**
+
+```bash
+git rm .github/workflows/deploy-local.yml
+```
+
+- [ ] **Step 3: Lint, commit, push**
+
+```bash
+actionlint .github/workflows/deploy.yml
+yamllint --strict .github/workflows/deploy.yml
+git add .github/workflows/deploy.yml
+git commit -m "feat(deploy): cut docker-piwine-office over to self-hosted runner"
+git push
+```
+
+- [ ] **Step 4: Verify next merge to `main` triggers a green deploy**
+
+Wait for next Renovate PR or push. Watch end-to-end. Green = pilot live.
+
+---
+
+## Phase 5 — Bake-In and Rollout Decision
+
+- [ ] **Step 1: Observe ~2 weeks of normal Renovate-driven deploys**
+
+Track: deploy duration vs baseline (expect ~30-90s shaved); any failures and root causes; anything Tailscale/SSH was implicitly providing that's now missing.
+
+- [ ] **Step 2: Decision**
+
+Green: write a follow-up plan for `docker-piwine` migration. The `runs-on` strategy decision (spec section "`runs-on` strategy") MUST be made before the second migration: pick option 1 (input-interpolation, verified), option 2 (per-repo workflow), or option 3 (matrix). Without that decision, the second migration adds risk.
+
+Red: diagnose, fix in `compose-workflow`, re-bake. Pilot is one-way — no SSH fallback.
+
+---
+
+## Out-of-Scope for This Plan
+
+- Migrating `docker-piwine` and `docker-zendc` (separate plans post-bake).
+- Deleting the SSH-based `deploy.yml` from `compose-workflow` (only after all three migrate; the SSH scripts go with it).
+- Picking among `runs-on` strategy options 1/2/3 (deferred to second-repo migration plan).
+- Runner version pinning automation (manual at install; revisit if it becomes a maintenance burden).
+- Adding `tj-actions/changed-files` self-hosted compatibility verification — assumed working; if not, the workflow must fall back to a `git diff --name-only $previous_sha $target-ref` step inside the `prepare` job.

--- a/docs/superpowers/specs/2026-04-29-self-hosted-deploy-runner-pilot-design.md
+++ b/docs/superpowers/specs/2026-04-29-self-hosted-deploy-runner-pilot-design.md
@@ -54,6 +54,12 @@ Today, the deploy reusable workflow (`compose-workflow/.github/workflows/deploy.
 
 **Runner labels:** `self-hosted, Linux, ARM64, piwine-office`. The first three are auto-assigned by GitHub at registration; only `piwine-office` is specified explicitly. This per-repo label keeps each future runner independently targetable.
 
+**`runs-on` strategy:** For the pilot, `deploy-local.yml` hardcodes `runs-on: [self-hosted, piwine-office]`. GitHub Actions does support label expressions in `runs-on`, but reusable-workflow input interpolation in `runs-on` arrays has had inconsistent behavior across runner versions, so the pilot avoids it. When rolling to `docker-piwine` and `docker-zendc`, the implementer must choose one of:
+1. Parameterize via `runs-on: [self-hosted, "${{ inputs.runner-label }}"]` — verify against the runner version in use and pin behavior in a smoke-test workflow before relying on it.
+2. Maintain one reusable workflow per repo (`deploy-local-piwine.yml`, etc.) with the label hardcoded — verbose but unambiguous.
+3. Use a matrix with a single entry — works around the input-in-`runs-on` issue at the cost of an extra YAML layer.
+The plan-implementer must pick one explicitly during pilot bake-in, before the second-repo migration. Keeping option 1 unverified through to the second migration is the failure mode to avoid.
+
 ## Host Setup (One-Time)
 
 Performed by a human admin with sudo. After completion, no runtime sudo is required.
@@ -64,7 +70,7 @@ sudo useradd -m -s /bin/bash deploy
 sudo usermod -aG docker deploy
 # Verify: as deploy, `docker ps` works without sudo
 
-# 2. Hand over compose paths to the deploy user
+# 2. Hand over the compose and dockge paths to the deploy user
 sudo chown -R deploy:deploy /opt/compose /opt/dockge
 
 # 3. Install runner (as deploy user)
@@ -146,6 +152,14 @@ The invariant: **`/opt/compose` HEAD must remain at the previous SHA when change
 1. **Step 3 must precede step 8.** `previous_sha` is read from `/opt/compose` HEAD; once step 8 hard-resets, that reading is gone.
 2. **Step 7 must precede step 8.** Removed stacks need their old `compose.yaml` to do `docker compose down` cleanly. After the hard reset those files are gone.
 3. **Steps 4–6 do not touch `/opt/compose`.** They run inside the runner's `_work/` checkout, which is at the new SHA. Pure metadata work.
+
+### Recovery from partial failure between steps 7 and 8
+
+If `docker compose down` succeeds for one or more removed stacks and the job is then cancelled or the runner crashes *before* step 8 completes, the host is left with: services stopped, `/opt/compose` still on `previous_sha`. On the next workflow run, Phase 1 will read `/opt/compose` HEAD as `previous_sha` (unchanged), `target-ref` will be the new SHA (or possibly the same one, if re-running the same deploy), and `detect-stack-changes.sh` will again classify those stacks as removed. Step 7 will issue `docker compose down` against already-stopped stacks (idempotent, no-op or near-no-op), and step 8 will then complete the reset. The torn-down removed stacks remain torn down, which is the desired outcome. If instead the operator wants to *resurrect* a removed stack mid-failure, they must do so manually (re-add the directory to the repo, re-deploy) — the workflow is not designed to undo a partially-applied removal automatically.
+
+### Runner workspace staleness
+
+The runner reuses `_work/` across jobs. `actions/checkout@v6` with `fetch-depth: 0` and an explicit `ref` will fetch and reset the workspace to match `target-ref` reliably. If a prior job leaves `_work/` in a dirty or detached state, the next checkout normalizes it. There is no SSH sandbox to blow away between runs; the runner host is the persistent environment. No special handling is required, but operators should be aware that any debugging artifacts written into `_work/` will be visible to subsequent jobs until cleared.
 
 ## Reuse vs. Duplication
 

--- a/docs/superpowers/specs/2026-04-29-self-hosted-deploy-runner-pilot-design.md
+++ b/docs/superpowers/specs/2026-04-29-self-hosted-deploy-runner-pilot-design.md
@@ -1,0 +1,192 @@
+# Self-Hosted Deploy Runner Pilot — Design
+
+**Status:** Approved (design phase)
+**Date:** 2026-04-29
+**Scope:** Pilot self-hosted GitHub Actions runner for `docker-piwine-office`. Lint stays on GitHub-hosted runners.
+
+## Background
+
+Today, the deploy reusable workflow (`compose-workflow/.github/workflows/deploy.yml`) runs on `ubuntu-24.04`, brings up Tailscale, then SSH-multiplexes commands to the deploy server. A previous attempt to move workflows wholesale onto a self-hosted runner was abandoned because `tailscale/github-action` requires sudoers rules to install its own binary into `/usr/local/bin` and run `sudo tailscale up`.
+
+**Key insight for this design:** if the runner *is* the deploy target, Tailscale is unnecessary — there is no remote to reach. That sidesteps the original blocker entirely.
+
+## Goals
+
+- Eliminate Tailscale install + SSH overhead from the deploy path on `docker-piwine-office`.
+- Run `docker compose` operations directly on the host, with no SSH round-trips for health checks.
+- Achieve zero sudo at runtime; only one-time sudo at host setup (user creation, ownership, service install).
+- Preserve all current behaviors: stack categorization (removed/existing/new), critical detection, rollback, Discord notifications, dockge handling.
+
+## Non-Goals
+
+- Migrating `docker-piwine` or `docker-zendc` (deferred to post-pilot rollout).
+- Running lint on the self-hosted runner.
+- Providing an automated SSH fallback. If the runner host is down, deploys pause until it returns; manual `docker compose` on the box is the only escape hatch.
+- Ephemeral or autoscaled runners (single persistent runner per host).
+
+## Architecture
+
+```
+┌─────────────────────────────┐         ┌──────────────────────────────────────┐
+│ GitHub-hosted (ubuntu-24.04)│         │ docker-piwine-office host (self-hosted)│
+│                             │         │                                       │
+│ • compose-lint.yml          │         │ • runner systemd service              │
+│ • workflow-lint.yml         │  ─────▶ │ • runs as `deploy` user (docker grp)  │
+│ • PR checks                 │         │ • workspace: ~/actions-runner/_work   │
+│                             │         │ • deploy-local.yml executes here:     │
+│                             │         │   - read /opt/compose HEAD            │
+│                             │         │   - change detection in _work/        │
+│                             │         │   - git reset --hard /opt/compose     │
+│                             │         │   - docker compose pull/up/down       │
+│                             │         │   - health check via local docker     │
+│                             │         │   - Discord notify (curl)             │
+└─────────────────────────────┘         └──────────────────────────────────────┘
+```
+
+**New file:** `compose-workflow/.github/workflows/deploy-local.yml` — reusable workflow with `runs-on: [self-hosted, piwine-office]`.
+
+**Modified file:** `docker-piwine-office/.github/workflows/deploy.yml` — caller invokes `deploy-local.yml` instead of `deploy.yml`.
+
+**Unchanged:**
+- `compose-lint.yml`, `workflow-lint.yml` (still on `ubuntu-24.04`).
+- `deploy.yml` (existing SSH workflow) — kept during pilot for `docker-piwine` and `docker-zendc`. Deleted only after all three repos migrate.
+- 1Password integration via `OP_SERVICE_ACCOUNT_TOKEN`.
+
+**Runner labels:** `self-hosted, Linux, ARM64, piwine-office`. The first three are auto-assigned by GitHub at registration; only `piwine-office` is specified explicitly. This per-repo label keeps each future runner independently targetable.
+
+## Host Setup (One-Time)
+
+Performed by a human admin with sudo. After completion, no runtime sudo is required.
+
+```bash
+# 1. Create dedicated user and grant docker access
+sudo useradd -m -s /bin/bash deploy
+sudo usermod -aG docker deploy
+# Verify: as deploy, `docker ps` works without sudo
+
+# 2. Hand over compose paths to the deploy user
+sudo chown -R deploy:deploy /opt/compose /opt/dockge
+
+# 3. Install runner (as deploy user)
+# Registration token from: github.com/owine/docker-piwine-office → Settings → Actions → Runners
+mkdir -p ~/actions-runner && cd ~/actions-runner
+# (download + extract latest runner from GitHub releases)
+./config.sh --url https://github.com/owine/docker-piwine-office \
+            --token <REGISTRATION_TOKEN> \
+            --labels piwine-office \
+            --unattended
+
+# 4. Install as systemd service running as deploy user
+sudo ./svc.sh install deploy
+sudo ./svc.sh start
+```
+
+The `svc.sh install deploy` argument makes the systemd unit run as the `deploy` user — this is the only sudo-touched step at install time, and there is no runtime sudo afterward.
+
+## Workflow: `deploy-local.yml`
+
+### Inputs
+
+| Input | Type | Notes |
+|---|---|---|
+| `runner-label` | string | e.g. `piwine-office`. Plumbed into `runs-on`. |
+| `live-repo-path` | string | e.g. `/opt/compose`. The persistent working tree. |
+| `repo-name` | string | For Discord messages. |
+| `webhook-url` | string | 1Password reference. |
+| `discord-user-id` | string | 1Password reference. |
+| `target-ref` | string | Commit SHA to deploy. |
+| `has-dockge` | boolean | Same semantics as existing `deploy.yml`. |
+| `force-deploy` | boolean | Same semantics as existing `deploy.yml`. |
+| (timeout inputs) | numbers | Same as existing `deploy.yml`. |
+
+### Step Ordering
+
+The invariant: **`/opt/compose` HEAD must remain at the previous SHA when change detection runs.** All updates to the live tree happen *after* detection.
+
+#### Phase 1 — Read state, do not mutate `/opt/compose`
+
+1. **`actions/checkout`** into `_work/` with `fetch-depth: 0` and `ref: target-ref`. Used for change-detection metadata; not the deploy target.
+2. **Load 1Password secrets** via `1password/load-secrets-action`.
+3. **Capture `previous_sha`** from the live tree:
+   ```bash
+   CURRENT_SHA=$(git -C /opt/compose rev-parse HEAD)
+   # Validate 40-hex; fall back to HEAD^ if invalid
+   ```
+   No SSH retry needed — this is a local filesystem read.
+4. **`tj-actions/changed-files`** in `_work/`, `base_sha=previous_sha`, `sha=target-ref`.
+5. **`detect-stack-changes.sh`** in `_work/`, consuming `previous_sha`, `target-ref`, and the changed-files JSON. Outputs `removed_stacks`, `existing_stacks`, `new_stacks`.
+6. **`detect-critical-stacks.sh`** in `_work/` — scans `compose.yaml` labels.
+
+#### Phase 2 — Mutate `/opt/compose`, deploy
+
+7. **Stop removed stacks** using the *pre-reset* tree (the only place those stacks' compose files still exist):
+   ```bash
+   for stack in $removed_stacks; do
+     docker compose -f /opt/compose/$stack/compose.yaml down
+   done
+   ```
+   This is a deviation from current `deploy.yml`, which does the SSH'd `git checkout` first. On self-hosted there is only one working tree, so teardown must precede the reset.
+8. **Update live tree** — *the point of no return for change detection:*
+   ```bash
+   git -C /opt/compose fetch
+   git -C /opt/compose reset --hard $TARGET_REF
+   ```
+9. **Discord notify (removed)** — can run any time after step 5; placed here to batch.
+10. **`deploy-stacks.sh` (existing stacks)** — uses `/opt/compose` paths now on the new SHA. `--has-dockge` causes dockge deploy from `/opt/dockge` after git is current (existing behavior preserved).
+11. **`deploy-stacks.sh` (new stacks)** — only if existing succeeded.
+
+#### Phase 3 — Verify and branch
+
+12. **`health-check.sh`**.
+13. **On failure:** `cleanup-stack.sh` for failed new stacks, then `rollback-stacks.sh` (`git reset --hard $previous_sha` on `/opt/compose` and redeploy).
+14. **Discord notify** — success or failure with metrics.
+
+### Three ordering points to call out explicitly
+
+1. **Step 3 must precede step 8.** `previous_sha` is read from `/opt/compose` HEAD; once step 8 hard-resets, that reading is gone.
+2. **Step 7 must precede step 8.** Removed stacks need their old `compose.yaml` to do `docker compose down` cleanly. After the hard reset those files are gone.
+3. **Steps 4–6 do not touch `/opt/compose`.** They run inside the runner's `_work/` checkout, which is at the new SHA. Pure metadata work.
+
+## Reuse vs. Duplication
+
+What stays identical to current `deploy.yml` (so the pilot is apples-to-apples):
+- `detect-stack-changes.sh`, `detect-critical-stacks.sh`, `deploy-stacks.sh`, `health-check.sh`, `rollback-stacks.sh`, `cleanup-stack.sh` — all reused unmodified.
+- Stack categorization (removed/existing/new), critical detection, sequential deployment.
+- Discord message format.
+
+What gets deleted in the local path:
+- Tailscale install + cache.
+- SSH multiplexing setup, `ssh-helpers.sh` retry calls (commands run locally; failures are immediately visible).
+- `SSH_USER` / `SSH_HOST` references (secrets stay in repo settings — used by other repos still on `deploy.yml`).
+
+What gets *better* on self-hosted:
+- ~30–60s saved per run on Tailscale install.
+- Health checks run locally — no SSH round-trip per `docker compose ps` call.
+
+## Failure Modes
+
+| Risk | Mitigation |
+|---|---|
+| Runner host down | Deploys pause until host is restored. Manual `docker compose` remains available to the human admin. No automated fallback. |
+| Runner workspace fills disk | `_work/` reused across jobs; checkout is small. Re-evaluate if observed; not blocking pilot. |
+| `git reset --hard` blows away local edits in `/opt/compose` | Same behavior as current `deploy-stacks.sh`. No change. |
+| Concurrent runs racing on `/opt/compose` | `concurrency: { group: deploy-piwine-office, cancel-in-progress: false }` on the caller workflow. |
+| `safe.directory` git error after chown | Resolved by `chown -R deploy:deploy /opt/compose /opt/dockge` at setup. |
+| Pilot fails midway | Phase 3 rollback restores `previous_sha` and redeploys. If rollback fails, human admin intervenes on the box directly. |
+
+## Rollout Plan
+
+1. **Pilot:** `docker-piwine-office` only. Caller's `deploy.yml` switches to invoke `deploy-local.yml`. The reusable `deploy.yml` (SSH-based) is unchanged and continues to serve `docker-piwine` and `docker-zendc`.
+2. **Bake-in:** ~2 weeks of normal Renovate-driven deploys. Watch for anything Tailscale/SSH was implicitly providing that has been lost.
+3. **If green — roll forward:**
+   - Register a runner on `docker-piwine`'s host with label `piwine`. Migrate caller. Confirm.
+   - Register a runner on `docker-zendc`'s host with label `zendc`. Migrate caller. This is the first exercise of `has-dockge: false` through `deploy-local.yml`.
+   - After all three migrated and stable, delete `deploy.yml` (the SSH version) from `compose-workflow`.
+4. **If red:** diagnose and fix the runner setup. The pilot is one-way; there is no SSH fallback.
+
+## Open Items for Implementation Plan
+
+- Exact runner version pinning strategy (release URL vs. configuration management).
+- Decision on whether `live-repo-path` should be a workflow input or hardcoded per caller (likely input, defaulted in caller workflow).
+- Whether to keep the `runner` input on the existing `deploy.yml` reusable workflow once it is no longer the only workflow that needs it.
+- Concurrency group naming convention if runners ever serve more than one repo.

--- a/scripts/deployment/detect-stack-changes.sh
+++ b/scripts/deployment/detect-stack-changes.sh
@@ -100,11 +100,13 @@ run_remote() {
       LIVE_REPO_PATH="$LIVE_REPO_PATH" bash -s
     fi
   else
+    local quoted_path
+    quoted_path=$(printf '%q' "$LIVE_REPO_PATH")
     local quoted_args=""
     if [[ $# -gt 0 ]]; then
-      quoted_args="${*@Q}"
+      quoted_args=$(printf '%q ' "$@")
     fi
-    ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST env LIVE_REPO_PATH=${LIVE_REPO_PATH@Q} /bin/bash -s $quoted_args"
+    ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST env LIVE_REPO_PATH=$quoted_path /bin/bash -s $quoted_args"
   fi
 }
 

--- a/scripts/deployment/detect-stack-changes.sh
+++ b/scripts/deployment/detect-stack-changes.sh
@@ -92,6 +92,15 @@ fi
 # Usage: echo "<bash script>" | run_remote arg1 arg2 ...
 # LIVE_REPO_PATH is propagated to the remote/local shell so heredoc bodies can
 # reference "$LIVE_REPO_PATH" agnostic of execution mode.
+#
+# SSH-mode quoting note: positional args are passed through `printf '%q'` and
+# interpolated into the command string given to ssh_retry. Since ssh_retry's
+# command goes through `ssh user@host <space-joined-args>` (which the remote
+# shell re-parses), a single round of `%q` quoting is the correct level for
+# this codebase: all callers pass SHAs, base64-encoded strings, or stack names
+# matching ^[a-zA-Z0-9._-]+$ -- none of which contain whitespace or shell
+# metacharacters. Do not pass user-controlled or unsanitized data through
+# this function.
 run_remote() {
   if [[ "$MODE" == "local" ]]; then
     if [[ $# -gt 0 ]]; then

--- a/scripts/deployment/detect-stack-changes.sh
+++ b/scripts/deployment/detect-stack-changes.sh
@@ -19,6 +19,8 @@ INPUT_STACKS="[]"
 REMOVED_FILES="[]"
 SSH_USER=""
 SSH_HOST=""
+MODE="ssh"
+LIVE_REPO_PATH="${LIVE_REPO_PATH:-}"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -47,6 +49,14 @@ while [[ $# -gt 0 ]]; do
       SSH_HOST="$2"
       shift 2
       ;;
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --live-repo-path)
+      LIVE_REPO_PATH="$2"
+      shift 2
+      ;;
     *)
       log_error "Unknown argument: $1"
       exit 1
@@ -58,8 +68,45 @@ done
 require_var CURRENT_SHA || exit 1
 require_var TARGET_REF || exit 1
 require_var INPUT_STACKS || exit 1
-require_var SSH_USER || exit 1
-require_var SSH_HOST || exit 1
+
+# Validate mode
+if [[ "$MODE" != "ssh" && "$MODE" != "local" ]]; then
+  echo "❌ --mode must be 'ssh' or 'local', got: $MODE"
+  exit 1
+fi
+
+if [[ "$MODE" == "ssh" ]]; then
+  require_var SSH_USER || exit 1
+  require_var SSH_HOST || exit 1
+  # Preserve historical default for SSH mode (remote tree path)
+  : "${LIVE_REPO_PATH:=/opt/compose}"
+else
+  # local mode requires LIVE_REPO_PATH
+  if [[ -z "$LIVE_REPO_PATH" ]]; then
+    log_error "--live-repo-path (or LIVE_REPO_PATH env) is required when --mode local"
+    exit 1
+  fi
+fi
+
+# run_remote: dispatches a bash script body (stdin) to either local bash or SSH.
+# Usage: echo "<bash script>" | run_remote arg1 arg2 ...
+# LIVE_REPO_PATH is propagated to the remote/local shell so heredoc bodies can
+# reference "$LIVE_REPO_PATH" agnostic of execution mode.
+run_remote() {
+  if [[ "$MODE" == "local" ]]; then
+    if [[ $# -gt 0 ]]; then
+      LIVE_REPO_PATH="$LIVE_REPO_PATH" bash -s "$@"
+    else
+      LIVE_REPO_PATH="$LIVE_REPO_PATH" bash -s
+    fi
+  else
+    local quoted_args=""
+    if [[ $# -gt 0 ]]; then
+      quoted_args="${*@Q}"
+    fi
+    ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST LIVE_REPO_PATH=${LIVE_REPO_PATH@Q} /bin/bash -s $quoted_args"
+  fi
+}
 
 # Parse input stacks JSON to space-delimited list
 INPUT_STACKS_LIST=$(echo "$INPUT_STACKS" | jq -r '.[]' | tr '\n' ' ')
@@ -104,7 +151,7 @@ detect_removed_stacks_gitdiff() {
   CURRENT_SHA="$1"
   TARGET_REF="$2"
 
-  cd /opt/compose
+  cd "$LIVE_REPO_PATH"
 
   # Fetch target ref to ensure we have it
   if ! git fetch origin "$TARGET_REF" 2>/dev/null; then
@@ -136,7 +183,7 @@ detect_removed_stacks_gitdiff() {
 DETECT_EOF
   )
 
-  echo "$detect_script" | ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST /bin/bash -s \"$current_sha\" \"$target_ref\""
+  echo "$detect_script" | run_remote "$current_sha" "$target_ref"
 }
 
 # === DETECTION FUNCTION: TREE COMPARISON (REMOVED) ===
@@ -150,7 +197,7 @@ detect_removed_stacks_tree() {
   set -e
   TARGET_REF="$1"
 
-  cd /opt/compose
+  cd "$LIVE_REPO_PATH"
 
   # Fetch target ref to ensure we have it
   if ! git fetch origin "$TARGET_REF" 2>/dev/null; then
@@ -174,21 +221,21 @@ detect_removed_stacks_tree() {
   COMMIT_DIRS=$(git ls-tree --name-only "$TARGET_SHA" 2>/dev/null | sort)
 
   # Get directories on server filesystem (exclude .git and hidden dirs)
-  SERVER_DIRS=$(find /opt/compose -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \; 2>/dev/null | sort)
+  SERVER_DIRS=$(find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \; 2>/dev/null | sort)
 
   # Find directories on server but not in commit
   MISSING_IN_COMMIT=$(comm -13 <(echo "$COMMIT_DIRS") <(echo "$SERVER_DIRS"))
 
   # Filter for directories with compose.yaml files
   for dir in $MISSING_IN_COMMIT; do
-    if [ -f "/opt/compose/$dir/compose.yaml" ]; then
+    if [ -f "$LIVE_REPO_PATH/$dir/compose.yaml" ]; then
       echo "$dir"
     fi
   done
 DETECT_TREE_EOF
   )
 
-  echo "$detect_script" | ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST /bin/bash -s \"$target_ref\""
+  echo "$detect_script" | run_remote "$target_ref"
 }
 
 # === DETECTION FUNCTION: DISCOVERY ANALYSIS (REMOVED) ===
@@ -214,7 +261,7 @@ detect_removed_stacks_discovery() {
 DETECT_DISCOVERY_EOF
   )
 
-  echo "$detect_script" | ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST /bin/bash -s \"$removed_files_b64\""
+  echo "$detect_script" | run_remote "$removed_files_b64"
 }
 
 # ================================================================
@@ -234,7 +281,7 @@ detect_new_stacks_gitdiff() {
   CURRENT_SHA="$1"
   TARGET_REF="$2"
 
-  cd /opt/compose
+  cd "$LIVE_REPO_PATH"
 
   # Fetch target ref to ensure we have it
   if ! git fetch origin "$TARGET_REF" 2>/dev/null; then
@@ -265,7 +312,7 @@ detect_new_stacks_gitdiff() {
 DETECT_NEW_EOF
   )
 
-  echo "$detect_script" | ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST /bin/bash -s \"$current_sha\" \"$target_ref\""
+  echo "$detect_script" | run_remote "$current_sha" "$target_ref"
 }
 
 # === DETECTION FUNCTION: TREE COMPARISON (NEW) ===
@@ -279,7 +326,7 @@ detect_new_stacks_tree() {
   set -e
   TARGET_REF="$1"
 
-  cd /opt/compose
+  cd "$LIVE_REPO_PATH"
 
   # Fetch target ref to ensure we have it
   if ! git fetch origin "$TARGET_REF" 2>/dev/null; then
@@ -306,8 +353,8 @@ detect_new_stacks_tree() {
   done | sort)
 
   # Get directories on server filesystem with compose.yaml
-  SERVER_STACKS=$(find /opt/compose -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \; 2>/dev/null | while read -r dir; do
-    if [ -f "/opt/compose/$dir/compose.yaml" ]; then
+  SERVER_STACKS=$(find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \; 2>/dev/null | while read -r dir; do
+    if [ -f "$LIVE_REPO_PATH/$dir/compose.yaml" ]; then
       echo "$dir"
     fi
   done | sort)
@@ -317,7 +364,7 @@ detect_new_stacks_tree() {
 DETECT_NEW_TREE_EOF
   )
 
-  echo "$detect_script" | ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST /bin/bash -s \"$target_ref\""
+  echo "$detect_script" | run_remote "$target_ref"
 }
 
 # === DETECTION FUNCTION: INPUT FILTER (NEW) ===
@@ -330,18 +377,18 @@ detect_new_stacks_input() {
   local detect_script
   detect_script=$(cat << 'DETECT_INPUT_EOF'
   set -e
-  cd /opt/compose
+  cd "$LIVE_REPO_PATH"
 
   # Get directories with compose.yaml files
-  find /opt/compose -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \; 2>/dev/null | while read -r dir; do
-    if [ -f "/opt/compose/$dir/compose.yaml" ]; then
+  find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \; 2>/dev/null | while read -r dir; do
+    if [ -f "$LIVE_REPO_PATH/$dir/compose.yaml" ]; then
       echo "$dir"
     fi
   done | sort
 DETECT_INPUT_EOF
   )
 
-  DEPLOYED_STACKS=$(echo "$detect_script" | ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST /bin/bash")
+  DEPLOYED_STACKS=$(echo "$detect_script" | run_remote)
 
   # Filter input stacks - those not in deployed stacks are new
   echo "$input_stacks" | jq -r '.[]' | while read -r stack; do

--- a/scripts/deployment/detect-stack-changes.sh
+++ b/scripts/deployment/detect-stack-changes.sh
@@ -71,7 +71,7 @@ require_var INPUT_STACKS || exit 1
 
 # Validate mode
 if [[ "$MODE" != "ssh" && "$MODE" != "local" ]]; then
-  echo "❌ --mode must be 'ssh' or 'local', got: $MODE"
+  log_error "--mode must be 'ssh' or 'local', got: $MODE"
   exit 1
 fi
 
@@ -104,7 +104,7 @@ run_remote() {
     if [[ $# -gt 0 ]]; then
       quoted_args="${*@Q}"
     fi
-    ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST LIVE_REPO_PATH=${LIVE_REPO_PATH@Q} /bin/bash -s $quoted_args"
+    ssh_retry 3 5 "ssh -o \"StrictHostKeyChecking no\" $SSH_USER@$SSH_HOST env LIVE_REPO_PATH=${LIVE_REPO_PATH@Q} /bin/bash -s $quoted_args"
   fi
 }
 


### PR DESCRIPTION
## Summary

Pilot infrastructure for moving `docker-piwine-office` deploys onto a self-hosted GitHub Actions runner (eliminating Tailscale + SSH from the deploy path). Two parallel changes:

- **`detect-stack-changes.sh`** gains a `--mode local` flag (default `ssh` = backward compat). The other heredoc-driven scripts (`deploy-stacks.sh`, `health-check.sh`, etc.) are untouched — their logic moves inline into the new workflow instead.
- **`deploy-local.yml`** (new reusable workflow) runs deploys workflow-natively on `[self-hosted, piwine-office]`. 10 jobs, per-stack matrix for parallelism, no SSH, no Tailscale. Dormant until a caller invokes it.

`deploy.yml` (the SSH workflow) is unchanged — `docker-piwine` and `docker-zendc` keep using it during the pilot.

## Design / plan

- Spec: `docs/superpowers/specs/2026-04-29-self-hosted-deploy-runner-pilot-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-self-hosted-deploy-runner-pilot.md`

## Test plan

- [ ] `actionlint .github/workflows/deploy-local.yml` clean (verified locally)
- [ ] `yamllint --strict .github/workflows/deploy-local.yml` clean (verified locally)
- [ ] `shellcheck scripts/deployment/detect-stack-changes.sh` clean (verified locally)
- [ ] After merge: trigger a real deploy on `docker-piwine` (Renovate or manual) to verify SSH path still works for the unchanged callers
- [ ] Phase 3 (host setup on piwine-office) — out of scope for this PR
- [ ] Phase 4 (caller wiring + smoke test) — out of scope for this PR

## Summary by Sourcery

Introduce a self-hosted, workflow-native deployment path for docker-piwine-office while keeping existing SSH-based deploys intact during a pilot.

New Features:
- Add a local execution mode to detect-stack-changes.sh to support running change detection directly on the deploy host without SSH.
- Create a reusable deploy-local.yml workflow that runs end-to-end Docker Compose deploys on a self-hosted runner with per-stack matrix jobs and integrated health, rollback, and notifications.

Enhancements:
- Generalize compose path handling in detect-stack-changes.sh via a configurable LIVE_REPO_PATH to work in both SSH and local modes.
- Document the self-hosted deploy runner pilot with a detailed design spec and implementation plan, including runner setup and rollout strategy.
- Configure actionlint for the new self-hosted runner label via a repository-level actionlint config.