### PR TITLE
build(renovate): add OSV + Scorecard, pin ranges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
+    "security:openssf-scorecard",
     ":semanticPrefixFixDepsChoreOthers"
   ],
   "labels": [
@@ -14,9 +15,11 @@
   "automergeSchedule": [
     "at any time"
   ],
-  "rangeStrategy": "bump",
+  "rangeStrategy": "pin",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
+  "osvVulnerabilityAlerts": true,
+  "dependencyDashboardOSVVulnerabilitySummary": "all",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
Fleet Renovate audit follow-up.

The `compose-workflow` preset (inherited by `docker-piwine`, `docker-piwine-office`, `docker-zendc`) was the homelab family's config and carried none of the supply-chain hardening the main `owine/renovate-config` preset has. Surgical additions only — homelab ergonomics preserved:

| Change | |
|---|---|
| `security:openssf-scorecard` | added to `extends` |
| `osvVulnerabilityAlerts: true` + `dependencyDashboardOSVVulnerabilitySummary: all` | added |
| `rangeStrategy` | `bump` → `pin` |

**Unchanged on purpose:** grouped non-major automerge with `ignoreTests`, `pinDigests: false` for docker-compose (compose files stay hand-editable), weekly Monday schedule. No `minimumReleaseAge` soak added (not requested — would slow homelab image bumps).

Validated with `renovate-config-validator --strict`. Caller repos pick this up automatically on next Renovate run.

## Summary by Sourcery

Harden Renovate configuration for compose-based projects by enabling additional supply chain security checks and adjusting version range handling.

New Features:
- Enable OpenSSF Scorecard integration in the shared Renovate preset.
- Turn on OSV vulnerability alerts with dashboard summaries for dependencies.

Enhancements:
- Switch Renovate range strategy from bumping ranges to pinning versions in the shared preset.