### PR TITLE
feat: disabled stacks via .disabled marker file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -749,6 +749,8 @@ jobs:
           HAS_EXISTING: ${{ needs.prepare.outputs.has_existing_stacks }}
           HAS_NEW: ${{ needs.prepare.outputs.has_new_stacks }}
           REMOVED_STACKS: ${{ needs.prepare.outputs.removed_stacks }}
+          HAS_DISABLED: ${{ needs.prepare.outputs.has_disabled_stacks }}
+          DISABLED_STACKS: ${{ needs.prepare.outputs.disabled_stacks }}
           FORCE_DEPLOY: ${{ inputs.force-deploy }}
         run: |
           set -euo pipefail
@@ -861,6 +863,20 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+          # Disabled stacks line
+          disabled_line=""
+          if [[ "$HAS_DISABLED" == "true" ]]; then
+            disabled_names=$(echo "$DISABLED_STACKS" | jq -r '. | join(", ")' 2>/dev/null || echo "")
+            if [[ -n "$disabled_names" ]]; then
+              disabled_line="🛑 **Disabled stacks:** $disabled_names"
+            fi
+          fi
+          {
+            echo "disabled_line<<EOF"
+            echo "$disabled_line"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Load Discord webhook and user ID
         id: op-load-discord
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
@@ -881,6 +897,7 @@ jobs:
             ${{ steps.status.outputs.description }}
 
             ${{ steps.status.outputs.removed_line }}
+            ${{ steps.status.outputs.disabled_line }}
 
             ${{ steps.status.outputs.deployment_needed == 'true' && format('**🔄 Pipeline Status**
             {0}', steps.status.outputs.pipeline) || '' }}
@@ -947,6 +964,7 @@ jobs:
           DESCRIPTION: ${{ steps.status.outputs.description }}
           PIPELINE: ${{ steps.status.outputs.pipeline }}
           REMOVED_LINE: ${{ steps.status.outputs.removed_line }}
+          DISABLED_LINE: ${{ steps.status.outputs.disabled_line }}
           COMMIT_SUBJECT: ${{ steps.commit-msg.outputs.message }}
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,6 +167,7 @@ jobs:
           PREVIOUS_SHA: ${{ steps.previous-sha.outputs.previous_sha }}
           TARGET_REF: ${{ inputs.target-ref }}
           REMOVED_FILES: ${{ steps.changed-files.outputs.deleted_files != '' && steps.changed-files.outputs.deleted_files || '[]' }}
+          ADDED_FILES: ${{ steps.changed-files.outputs.added_files != '' && steps.changed-files.outputs.added_files || '[]' }}
           INPUT_STACKS: ${{ steps.discover-stacks.outputs.stacks }}
         run: |
           ./.compose-workflow/scripts/deployment/detect-stack-changes.sh \
@@ -174,7 +175,8 @@ jobs:
             --target-ref "$TARGET_REF" \
             --live-repo-path "$DETECTION_TREE" \
             --input-stacks "$INPUT_STACKS" \
-            --removed-files "$REMOVED_FILES"
+            --removed-files "$REMOVED_FILES" \
+            --added-files "$ADDED_FILES"
 
       - name: Detect critical stacks
         id: detect-critical

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,8 @@ jobs:
       has_removed_stacks: ${{ steps.detect-changes.outputs.has_removed_stacks }}
       has_existing_stacks: ${{ steps.detect-changes.outputs.has_existing_stacks }}
       has_new_stacks: ${{ steps.detect-changes.outputs.has_new_stacks }}
+      disabled_stacks: ${{ steps.discover-stacks.outputs.disabled_stacks }}
+      has_disabled_stacks: ${{ steps.discover-stacks.outputs.has_disabled_stacks }}
       critical_stacks: ${{ steps.detect-critical.outputs.critical_stacks }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -127,20 +129,32 @@ jobs:
         run: |
           set -euo pipefail
           cd "$DETECTION_TREE"
-          stacks=()
+          active=()
+          disabled=()
           for dir in */; do
             dir_name=$(basename "$dir")
             if [[ -f "$dir/compose.yml" || -f "$dir/compose.yaml" ]]; then
-              stacks+=("\"$dir_name\"")
+              if [[ -f "$dir/.disabled" ]]; then
+                disabled+=("\"$dir_name\"")
+              else
+                active+=("\"$dir_name\"")
+              fi
             fi
           done
-          if [ ${#stacks[@]} -eq 0 ]; then
+          if [ ${#active[@]} -eq 0 ] && [ ${#disabled[@]} -eq 0 ]; then
             echo "::error::No Docker Compose stacks found in repository"
             exit 1
           fi
-          stack_json="[$(IFS=,; echo "${stacks[*]}")]"
-          echo "stacks=$stack_json" >> "$GITHUB_OUTPUT"
-          echo "✅ Discovered stacks: $stack_json"
+          active_json="[$(IFS=,; echo "${active[*]}")]"
+          disabled_json="[$(IFS=,; echo "${disabled[*]}")]"
+          has_disabled=$([ ${#disabled[@]} -gt 0 ] && echo true || echo false)
+          {
+            echo "stacks=$active_json"
+            echo "disabled_stacks=$disabled_json"
+            echo "has_disabled_stacks=$has_disabled"
+          } >> "$GITHUB_OUTPUT"
+          echo "✅ Active stacks: $active_json"
+          echo "🛑 Disabled stacks: $disabled_json"
 
       - name: Detect stack changes
         id: detect-changes

--- a/docs/superpowers/plans/2026-05-26-disabled-stacks.md
+++ b/docs/superpowers/plans/2026-05-26-disabled-stacks.md
@@ -1,0 +1,859 @@
+# Disabled Stacks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `.disabled` marker file mechanism that causes the deploy workflow to `docker compose down` a stack on disable transition, without deleting the compose file from the repo.
+
+**Architecture:** Introduce an "effectively present at SHA" predicate (compose.yaml exists ∧ .disabled absent) inside `detect-stack-changes.sh`. With effectively-present-in-CURRENT guards on removed-stack detectors and effectively-present-in-TARGET guards on new-stack detectors, the disable transition naturally piggybacks on the existing removed-stack teardown path; re-enable piggybacks on the new-stack deploy path. Discovery in the deploy workflow filters out disabled stacks; lint discovery in caller repos is unchanged. A new `disabled_stacks` output drives Discord and PR-comment visibility.
+
+**Tech Stack:** Bash, GitHub Actions (reusable workflow), `tj-actions/changed-files`, `docker compose`, `jq`, `git cat-file`. Validation: `shellcheck`, `actionlint`, `yamllint --strict`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-26-disabled-stacks-design.md`](../specs/2026-05-26-disabled-stacks-design.md)
+
+---
+
+## File Inventory
+
+**Modify:**
+- `scripts/deployment/detect-stack-changes.sh` — add `--added-files` CLI flag, add `is_effectively_present_at_sha` helper, update all six detector functions with effective-presence guards
+- `.github/workflows/deploy.yml` — filter `.disabled` from `Discover stacks`, add `disabled_stacks` output, wire `added_files` to script invocation, render disabled-stacks line in Discord + PR comment
+- `scripts/deployment/build-pr-comment.sh` — accept `DISABLED_LINE` env var, render alongside `REMOVED_LINE`
+
+**Create:**
+- `scripts/testing/test-detect-stack-changes.sh` — bash test harness for unit-testing the classification script via throwaway git repos
+- `scripts/testing/fixtures/transition-cases.sh` — transition table scenarios sourced by the harness (kept separate so the harness file stays a runner, not a fixture catalog)
+
+**Touched but unchanged (verify only):**
+- Caller-repo lint workflows — confirm disabled stacks still flow through (they should, since caller-side discovery isn't filtered)
+
+---
+
+## Task 1: Build test harness + write failing transition fixtures (TDD: RED)
+
+**Files:**
+- Create: `scripts/testing/test-detect-stack-changes.sh`
+- Create: `scripts/testing/fixtures/transition-cases.sh`
+
+The harness constructs a throwaway git repo with two commits (CURRENT_SHA → TARGET_SHA) representing each transition row, runs `detect-stack-changes.sh` against it, and asserts the JSON outputs match expected. We write all 8 transition fixtures up front, run against the current (unmodified) script, and confirm: 3 rows pass (normal add/delete/update), 5 fail (the new disabled-related rows). This is the RED state.
+
+- [ ] **Step 1: Create harness skeleton with assertion helpers**
+
+Create `scripts/testing/test-detect-stack-changes.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Unit tests for scripts/deployment/detect-stack-changes.sh
+# Builds throwaway git repos per scenario, runs the script, asserts JSON outputs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DETECT_SCRIPT="$REPO_ROOT/scripts/deployment/detect-stack-changes.sh"
+
+# shellcheck source=fixtures/transition-cases.sh
+source "$SCRIPT_DIR/fixtures/transition-cases.sh"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# build_scenario <workdir> <current_setup_fn> <target_setup_fn>
+# Creates a git repo at <workdir> with two commits. Each setup fn is called
+# with the workdir as CWD and performs file mutations representing one SHA.
+# Returns CURRENT_SHA and TARGET_SHA via globals.
+build_scenario() {
+  local workdir="$1" current_fn="$2" target_fn="$3"
+  rm -rf "$workdir"
+  mkdir -p "$workdir"
+  (
+    cd "$workdir"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    "$current_fn"
+    git add -A
+    git commit -q -m "current"
+    CURRENT_SHA=$(git rev-parse HEAD)
+    "$target_fn"
+    git add -A
+    # Allow empty in case target_fn only deletes
+    git commit -q --allow-empty -m "target"
+    TARGET_SHA=$(git rev-parse HEAD)
+    echo "$CURRENT_SHA $TARGET_SHA"
+  )
+}
+
+# run_detect <workdir> <current_sha> <target_sha> <input_stacks_json> \
+#            [<removed_files_json>] [<added_files_json>]
+# Runs the detect script with GITHUB_OUTPUT redirected to a temp file,
+# returns the file path (caller parses it).
+run_detect() {
+  local workdir="$1" current="$2" target="$3" input="$4"
+  local removed="${5:-[]}" added="${6:-[]}"
+  local out
+  out=$(mktemp)
+  GITHUB_OUTPUT="$out" "$DETECT_SCRIPT" \
+    --current-sha "$current" \
+    --target-ref "$target" \
+    --live-repo-path "$workdir" \
+    --input-stacks "$input" \
+    --removed-files "$removed" \
+    --added-files "$added" \
+    >/dev/null 2>&1 || {
+      echo "::detect-script-failed::" >> "$out"
+    }
+  echo "$out"
+}
+
+# Read a GITHUB_OUTPUT-format key
+read_output() {
+  local file="$1" key="$2"
+  grep "^${key}=" "$file" | head -1 | cut -d= -f2-
+}
+
+# assert <case_name> <expected_removed_json> <expected_existing_json> \
+#        <expected_new_json> <output_file>
+assert_classifications() {
+  local name="$1" exp_removed="$2" exp_existing="$3" exp_new="$4" out="$5"
+  local got_removed got_existing got_new
+  got_removed=$(read_output "$out" removed_stacks)
+  got_existing=$(read_output "$out" existing_stacks)
+  got_new=$(read_output "$out" new_stacks)
+
+  if [[ "$got_removed" == "$exp_removed" \
+     && "$got_existing" == "$exp_existing" \
+     && "$got_new" == "$exp_new" ]]; then
+    echo "✅ $name"
+    PASS=$((PASS+1))
+  else
+    echo "❌ $name"
+    echo "   removed:  got=$got_removed  want=$exp_removed"
+    echo "   existing: got=$got_existing want=$exp_existing"
+    echo "   new:      got=$got_new      want=$exp_new"
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+  fi
+}
+
+# Run all transition test cases (defined in fixtures file).
+run_all_cases
+
+echo ""
+echo "========================================"
+echo "Tests: $((PASS+FAIL))  Passed: $PASS  Failed: $FAIL"
+echo "========================================"
+if [[ $FAIL -gt 0 ]]; then
+  printf 'Failures:\n'
+  printf '  - %s\n' "${FAILURES[@]}"
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Create transition fixtures**
+
+Create `scripts/testing/fixtures/transition-cases.sh`. Each function constructs one scenario and asserts expected output. The `--added-files` flag is referenced here but doesn't exist on the script yet — that's intentional; Task 2 adds it. For now, fixtures invoke the harness's `run_detect` which always passes `--added-files [] `. **Pre-Task 2 behavior:** the script will reject the unknown flag, so this entire file fails until Task 2 lands. To allow stepwise validation, we accept that the fixtures cannot run green until after Task 2; Task 1's "RED state" verification is "fixtures parse, harness assertion helpers work."
+
+```bash
+#!/usr/bin/env bash
+# Transition table scenarios for detect-stack-changes.sh tests.
+# Each function: builds scenario, runs script, asserts expected classification.
+
+case_normal_add() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _setup_empty _add_foo_enabled)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '[]' '["foo/compose.yaml"]')
+  assert_classifications "normal_add" '[]' '[]' '["foo"]' "$out"
+}
+_setup_empty() { :; }
+_add_foo_enabled() { mkdir -p foo; echo 'services: {a: {image: nginx}}' > foo/compose.yaml; }
+
+case_normal_delete() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _delete_foo)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '["foo/compose.yaml"]' '[]')
+  assert_classifications "normal_delete" '["foo"]' '[]' '[]' "$out"
+}
+_delete_foo() { rm -rf foo; }
+
+case_normal_update() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _modify_foo)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '[]' '[]')
+  assert_classifications "normal_update" '[]' '["foo"]' '[]' "$out"
+}
+_modify_foo() { echo 'services: {a: {image: nginx:1.27}}' > foo/compose.yaml; }
+
+case_disable() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _disable_foo)"
+  # Input stacks excludes foo because the discover step (workflow-side) filters
+  # .disabled-bearing dirs. Simulate that here.
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '["foo/.disabled"]')
+  assert_classifications "disable" '["foo"]' '[]' '[]' "$out"
+}
+_disable_foo() { touch foo/.disabled; }
+
+case_re_enable() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _enable_foo)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '["foo/.disabled"]' '[]')
+  assert_classifications "re_enable" '[]' '[]' '["foo"]' "$out"
+}
+_add_foo_disabled() {
+  mkdir -p foo; echo 'services: {a: {image: nginx}}' > foo/compose.yaml; touch foo/.disabled;
+}
+_enable_foo() { rm foo/.disabled; }
+
+case_stay_disabled() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _noop)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '[]')
+  assert_classifications "stay_disabled" '[]' '[]' '[]' "$out"
+}
+_noop() { :; }
+
+case_born_disabled() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _setup_empty _add_foo_disabled)"
+  # Both files appear as added; this is the regression case for the guard.
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '["foo/compose.yaml","foo/.disabled"]')
+  assert_classifications "born_disabled" '[]' '[]' '[]' "$out"
+}
+
+case_delete_while_disabled() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _delete_foo)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '["foo/compose.yaml","foo/.disabled"]' '[]')
+  assert_classifications "delete_while_disabled" '[]' '[]' '[]' "$out"
+}
+
+run_all_cases() {
+  case_normal_add
+  case_normal_delete
+  case_normal_update
+  case_disable
+  case_re_enable
+  case_stay_disabled
+  case_born_disabled
+  case_delete_while_disabled
+}
+```
+
+- [ ] **Step 3: Make harness + fixtures executable**
+
+```bash
+chmod +x scripts/testing/test-detect-stack-changes.sh
+```
+
+- [ ] **Step 4: Run the harness — expect catastrophic failure (RED)**
+
+```bash
+./scripts/testing/test-detect-stack-changes.sh || true
+```
+
+Expected: every test fails because the script will reject `--added-files` as an unknown argument. This is RED. The fixtures and harness assertion plumbing are validated by reading the output — confirm each case prints `❌ <name>` and that the failure messages include the script's "Unknown argument: --added-files" output (visible in script stderr; the harness suppresses it, but you can re-run one case manually to check).
+
+Manually verify:
+
+```bash
+"$(pwd)/scripts/deployment/detect-stack-changes.sh" --added-files '[]' 2>&1 | head -3
+```
+
+Expected: contains `Unknown argument: --added-files`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/testing/test-detect-stack-changes.sh scripts/testing/fixtures/transition-cases.sh
+git commit -m "test: harness + transition fixtures for detect-stack-changes"
+```
+
+---
+
+## Task 2: Add `--added-files` CLI plumbing
+
+**Files:**
+- Modify: `scripts/deployment/detect-stack-changes.sh` (arg parsing block at lines 24–42)
+
+No behavior change — just accept the flag so fixtures can pass it.
+
+- [ ] **Step 1: Add ADDED_FILES variable + argument parsing**
+
+In `detect-stack-changes.sh`, alongside `REMOVED_FILES`:
+
+```bash
+REMOVED_FILES="[]"
+ADDED_FILES="[]"
+```
+
+In the `while [[ $# -gt 0 ]]; do case $1 in ... esac done` block:
+
+```bash
+    --added-files)      ADDED_FILES="$2"; shift 2 ;;
+```
+
+- [ ] **Step 2: Re-run harness — still RED but for the *right* reasons now**
+
+```bash
+./scripts/testing/test-detect-stack-changes.sh || true
+```
+
+Expected: `normal_add`, `normal_delete`, `normal_update` pass (3 ✅); the five disabled-related cases fail (5 ❌). This proves: (a) the flag is now accepted, (b) existing behavior is preserved for non-disabled rows, (c) the disabled rows are correctly failing because the script doesn't yet know about `.disabled`.
+
+- [ ] **Step 3: Run shellcheck**
+
+```bash
+shellcheck scripts/deployment/detect-stack-changes.sh
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/deployment/detect-stack-changes.sh
+git commit -m "feat(detect): accept --added-files flag (no behavior change yet)"
+```
+
+---
+
+## Task 3: Add `is_effectively_present_at_sha` helper + apply to removed-stack detectors
+
+**Files:**
+- Modify: `scripts/deployment/detect-stack-changes.sh`
+
+Implements the effectively-present-in-CURRENT guard on all three removed detectors. After this task, the `disable` and `delete_while_disabled` fixtures should pass; `re_enable`, `stay_disabled`, and `born_disabled` will still fail (those need the symmetric new-detector guards in Task 4).
+
+- [ ] **Step 1: Add the helper**
+
+Inside the `run_local` helper block (around line 55), or as a top-level function above the detector functions, add:
+
+```bash
+# is_effectively_present_at_sha <sha> <stack>
+# Returns 0 iff <stack>/compose.yaml exists at <sha> AND <stack>/.disabled does not.
+# Must be invoked inside the LIVE_REPO_PATH git repo (i.e. inside a run_local block).
+is_effectively_present_at_sha() {
+  local sha="$1" stack="$2"
+  git cat-file -e "$sha:$stack/compose.yaml" 2>/dev/null || return 1
+  if git cat-file -e "$sha:$stack/.disabled" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+```
+
+Because each detector runs its body in a `bash -s` heredoc subshell via `run_local`, the helper must be defined *inside* each detector's heredoc OR exported through `LIVE_REPO_PATH` propagation. The simplest approach: inline the helper at the top of each detector's heredoc body. To keep things DRY, define the function body once as a bash string variable and prepend it to each heredoc:
+
+```bash
+# Helper text injected at the top of each detector heredoc.
+HELPER_FUNCS='
+is_effectively_present_at_sha() {
+  local sha="$1" stack="$2"
+  git cat-file -e "$sha:$stack/compose.yaml" 2>/dev/null || return 1
+  if git cat-file -e "$sha:$stack/.disabled" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+is_effectively_present_on_disk() {
+  local root="$1" stack="$2"
+  [[ -f "$root/$stack/compose.yaml" ]] || return 1
+  [[ ! -f "$root/$stack/.disabled" ]]
+}
+'
+```
+
+Then prepend `$HELPER_FUNCS` to each detector's heredoc body. This requires changing each detector's heredoc from a single-quoted `<< 'DETECT_EOF'` (literal, no interpolation) to a setup that injects the helpers. Cleanest pattern: keep the heredoc literal, but prepend the helpers via concatenation:
+
+```bash
+detect_removed_stacks_gitdiff() {
+  local current_sha="$1" target_ref="$2"
+  log_info "Running git diff detection for removed stacks..."
+  local detect_script
+  detect_script="$HELPER_FUNCS"$'\n'"$(cat << 'DETECT_EOF'
+  ...existing body...
+DETECT_EOF
+)"
+  echo "$detect_script" | run_local "$current_sha" "$target_ref"
+}
+```
+
+Apply this concatenation pattern to all six detectors.
+
+- [ ] **Step 2: Update `detect_removed_stacks_gitdiff` body**
+
+Replace the existing `git diff --diff-filter=D` line and downstream pipeline with logic that:
+1. Collects candidates from compose.yaml deletions (diff-filter `D`) AND `.disabled` additions (diff-filter `A`)
+2. For each candidate, emits only if `is_effectively_present_at_sha "$CURRENT_SHA" "$candidate"`
+
+```bash
+# Inside the heredoc body, replacing the existing single git-diff invocation:
+{
+  git diff --diff-filter=D --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null \
+    | grep -E '^[^/]+/compose\.yaml$' | sed 's|/compose\.yaml||' || true
+  git diff --diff-filter=A --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null \
+    | grep -E '^[^/]+/\.disabled$' | sed 's|/\.disabled||' || true
+} | sort -u | while read -r candidate; do
+  [[ -z "$candidate" ]] && continue
+  if is_effectively_present_at_sha "$CURRENT_SHA" "$candidate"; then
+    echo "$candidate"
+  fi
+done
+```
+
+- [ ] **Step 3: Update `detect_removed_stacks_tree` body**
+
+The current body computes `MISSING_IN_COMMIT` via filesystem comparison. Replace with:
+
+```bash
+# All directories that ever appeared at root in either tree or live filesystem.
+ALL_DIRS=$( {
+  git ls-tree --name-only "$TARGET_SHA" 2>/dev/null
+  find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \;
+} | sort -u )
+
+for dir in $ALL_DIRS; do
+  # Removed = effectively-present on live disk AND NOT effectively-present at target SHA.
+  if is_effectively_present_on_disk "$LIVE_REPO_PATH" "$dir" \
+     && ! is_effectively_present_at_sha "$TARGET_SHA" "$dir"; then
+    echo "$dir"
+  fi
+done
+```
+
+- [ ] **Step 4: Update `detect_removed_stacks_discovery` body**
+
+Currently keys only on `deleted_files`. Extend to merge `added_files` for `.disabled` markers, then apply the guard. Update the function signature to take both inputs:
+
+```bash
+detect_removed_stacks_discovery() {
+  local removed_files_json="$1" added_files_json="$2" current_sha="$3"
+  log_info "Running discovery analysis detection for removed stacks..."
+  local removed_b64 added_b64
+  removed_b64=$(echo -n "$removed_files_json" | base64 -w 0 2>/dev/null || echo -n "$removed_files_json" | base64)
+  added_b64=$(echo -n "$added_files_json" | base64 -w 0 2>/dev/null || echo -n "$added_files_json" | base64)
+
+  local detect_script
+  detect_script="$HELPER_FUNCS"$'\n'"$(cat << 'DETECT_DISCOVERY_EOF'
+  set -e
+  CURRENT_SHA="$3"
+  REMOVED_JSON=$(echo "$1" | base64 -d)
+  ADDED_JSON=$(echo "$2" | base64 -d)
+  cd "$LIVE_REPO_PATH"
+  {
+    echo "$REMOVED_JSON" | jq -r '.[]?' | grep -E '^[^/]+/compose\.yaml$' | sed 's|/compose\.yaml||' || true
+    echo "$ADDED_JSON"   | jq -r '.[]?' | grep -E '^[^/]+/\.disabled$'    | sed 's|/\.disabled||'    || true
+  } | sort -u | while read -r candidate; do
+    [[ -z "$candidate" ]] && continue
+    if is_effectively_present_at_sha "$CURRENT_SHA" "$candidate"; then
+      echo "$candidate"
+    fi
+  done
+DETECT_DISCOVERY_EOF
+)"
+  echo "$detect_script" | run_local "$removed_b64" "$added_b64" "$current_sha"
+}
+```
+
+Then update the caller (in the MAIN section) to pass the new arguments:
+
+```bash
+REMOVED_DISCOVERY=$(detect_removed_stacks_discovery "$REMOVED_FILES" "$ADDED_FILES" "$CURRENT_SHA") || REMOVED_DISCOVERY_EXIT=$?
+```
+
+Also remove the `if [ "$REMOVED_FILES" = "[]" ] ...` early-skip block — we now have two sources to check, so the function itself handles emptiness (the jq `.[]?` operator tolerates `[]`).
+
+- [ ] **Step 5: Run the harness — expect partial GREEN**
+
+```bash
+./scripts/testing/test-detect-stack-changes.sh || true
+```
+
+Expected: `normal_add`, `normal_delete`, `normal_update`, `disable`, `delete_while_disabled` pass (5 ✅); `re_enable`, `stay_disabled`, `born_disabled` still fail (3 ❌). The remaining failures are all on the new-stack detector side.
+
+- [ ] **Step 6: Run shellcheck**
+
+```bash
+shellcheck scripts/deployment/detect-stack-changes.sh
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/deployment/detect-stack-changes.sh
+git commit -m "feat(detect): effectively-present-in-CURRENT guard on removed detectors"
+```
+
+---
+
+## Task 4: Apply effectively-present-in-TARGET guards to new-stack detectors
+
+**Files:**
+- Modify: `scripts/deployment/detect-stack-changes.sh`
+
+Symmetric to Task 3. After this task all 8 fixtures should pass.
+
+- [ ] **Step 1: Update `detect_new_stacks_gitdiff` body**
+
+Replace the single `git diff --diff-filter=A` invocation with combined candidate collection + guard:
+
+```bash
+{
+  git diff --diff-filter=A --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null \
+    | grep -E '^[^/]+/compose\.yaml$' | sed 's|/compose\.yaml||' || true
+  git diff --diff-filter=D --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null \
+    | grep -E '^[^/]+/\.disabled$' | sed 's|/\.disabled||' || true
+} | sort -u | while read -r candidate; do
+  [[ -z "$candidate" ]] && continue
+  if is_effectively_present_at_sha "$TARGET_SHA" "$candidate"; then
+    echo "$candidate"
+  fi
+done
+```
+
+- [ ] **Step 2: Update `detect_new_stacks_tree` body**
+
+Replace `COMMIT_STACKS` / `SERVER_STACKS` / `comm -23` logic with:
+
+```bash
+ALL_DIRS=$( {
+  git ls-tree --name-only "$TARGET_SHA" 2>/dev/null
+  find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \;
+} | sort -u )
+
+for dir in $ALL_DIRS; do
+  # New = effectively-present at target SHA AND NOT effectively-present on live disk.
+  if is_effectively_present_at_sha "$TARGET_SHA" "$dir" \
+     && ! is_effectively_present_on_disk "$LIVE_REPO_PATH" "$dir"; then
+    echo "$dir"
+  fi
+done
+```
+
+- [ ] **Step 3: `detect_new_stacks_input` — verify no change needed**
+
+Read the function and confirm: it takes `INPUT_STACKS` (which, after Task 5's discover-stacks filter, will already exclude disabled stacks) and emits those not present on disk. The on-disk check (`-f compose.yaml`) is fine here because: if `INPUT_STACKS` only contains effectively-present-in-TARGET names, and the on-disk check is checking the *live* tree, then "not on live disk" = "new" remains correct. No edit needed.
+
+Confirm by reading lines 281–304 of the script.
+
+- [ ] **Step 4: Run the harness — expect full GREEN**
+
+```bash
+./scripts/testing/test-detect-stack-changes.sh
+```
+
+Expected: all 8 cases pass. `Tests: 8  Passed: 8  Failed: 0`. Exit code 0.
+
+- [ ] **Step 5: Run shellcheck**
+
+```bash
+shellcheck scripts/deployment/detect-stack-changes.sh
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/deployment/detect-stack-changes.sh
+git commit -m "feat(detect): effectively-present-in-TARGET guard on new detectors"
+```
+
+---
+
+## Task 5: Filter `.disabled` from `Discover stacks` + emit `disabled_stacks` output
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml` (lines 123–143 `Discover stacks` step + prepare job outputs at lines 70–78)
+
+- [ ] **Step 1: Update the `Discover stacks` step**
+
+Replace the step body to filter `.disabled` and emit a second JSON array:
+
+```yaml
+      - name: Discover stacks
+        id: discover-stacks
+        env:
+          DETECTION_TREE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          cd "$DETECTION_TREE"
+          active=()
+          disabled=()
+          for dir in */; do
+            dir_name=$(basename "$dir")
+            if [[ -f "$dir/compose.yml" || -f "$dir/compose.yaml" ]]; then
+              if [[ -f "$dir/.disabled" ]]; then
+                disabled+=("\"$dir_name\"")
+              else
+                active+=("\"$dir_name\"")
+              fi
+            fi
+          done
+          if [ ${#active[@]} -eq 0 ] && [ ${#disabled[@]} -eq 0 ]; then
+            echo "::error::No Docker Compose stacks found in repository"
+            exit 1
+          fi
+          active_json="[$(IFS=,; echo "${active[*]}")]"
+          disabled_json="[$(IFS=,; echo "${disabled[*]}")]"
+          echo "stacks=$active_json" >> "$GITHUB_OUTPUT"
+          echo "disabled_stacks=$disabled_json" >> "$GITHUB_OUTPUT"
+          echo "has_disabled_stacks=$([ ${#disabled[@]} -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "✅ Active stacks: $active_json"
+          echo "🛑 Disabled stacks: $disabled_json"
+```
+
+- [ ] **Step 2: Add new prepare job outputs**
+
+In the `prepare` job's `outputs:` block (lines 70–78), add:
+
+```yaml
+      disabled_stacks: ${{ steps.discover-stacks.outputs.disabled_stacks }}
+      has_disabled_stacks: ${{ steps.discover-stacks.outputs.has_disabled_stacks }}
+```
+
+- [ ] **Step 3: Validate with actionlint + yamllint**
+
+```bash
+actionlint .github/workflows/deploy.yml
+yamllint --strict .github/workflows/deploy.yml
+```
+
+Expected: both pass with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "feat(deploy): filter .disabled from discovery, emit disabled_stacks"
+```
+
+---
+
+## Task 6: Wire `added_files` into `detect-stack-changes.sh` invocation
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml` (Detect stack changes step around lines 145–163)
+
+- [ ] **Step 1: Pass `added_files` env var**
+
+In the `Detect stack changes` step's `env:` block, after `REMOVED_FILES`:
+
+```yaml
+          ADDED_FILES: ${{ steps.changed-files.outputs.added_files != '' && steps.changed-files.outputs.added_files || '[]' }}
+```
+
+And in the script invocation, add the new flag:
+
+```yaml
+          ./.compose-workflow/scripts/deployment/detect-stack-changes.sh \
+            --current-sha "$PREVIOUS_SHA" \
+            --target-ref "$TARGET_REF" \
+            --live-repo-path "$DETECTION_TREE" \
+            --input-stacks "$INPUT_STACKS" \
+            --removed-files "$REMOVED_FILES" \
+            --added-files "$ADDED_FILES"
+```
+
+- [ ] **Step 2: Validate**
+
+```bash
+actionlint .github/workflows/deploy.yml
+yamllint --strict .github/workflows/deploy.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "feat(deploy): wire added_files into stack change detection"
+```
+
+---
+
+## Task 7: Render `DISABLED_LINE` in `build-pr-comment.sh`
+
+**Files:**
+- Modify: `scripts/deployment/build-pr-comment.sh`
+
+- [ ] **Step 1: Add the env var default + render block**
+
+After line 18 (`: "${REMOVED_LINE:=}"`), add:
+
+```bash
+: "${DISABLED_LINE:=}"
+```
+
+After the existing removed-stacks rendering block (lines 53–56), add:
+
+```bash
+# Disabled-stacks line (only when present).
+if [[ -n "$DISABLED_LINE" ]]; then
+  printf '%s\n\n' "$DISABLED_LINE"
+fi
+```
+
+- [ ] **Step 2: Verify with shellcheck**
+
+```bash
+shellcheck scripts/deployment/build-pr-comment.sh
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Smoke test locally**
+
+```bash
+REPO_NAME=test TARGET_REF=abcdef0123456789 REPOSITORY=foo/bar \
+  RUN_ID=1 RUN_NUMBER=1 OVERALL=success TITLE_SUFFIX=ok \
+  REMOVED_LINE='🗑️ **Removed stacks:** foo' \
+  DISABLED_LINE='🛑 **Disabled stacks:** bar' \
+  ./scripts/deployment/build-pr-comment.sh
+```
+
+Expected output: includes both the 🗑️ removed line and the 🛑 disabled line as separate paragraphs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/deployment/build-pr-comment.sh
+git commit -m "feat(notify): render disabled-stacks line in PR comment"
+```
+
+---
+
+## Task 8: Build `disabled_line` in notify status step + wire through to Discord and PR comment
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml` (status step around lines 725–846, Discord step around lines 857–875, PR comment env around lines 925–940)
+
+- [ ] **Step 1: Pass `disabled_stacks` through the status step env**
+
+In the `Compute notification status` step (around line 725), add to the `env:` block:
+
+```yaml
+          HAS_DISABLED: ${{ needs.prepare.outputs.has_disabled_stacks }}
+          DISABLED_STACKS: ${{ needs.prepare.outputs.disabled_stacks }}
+```
+
+- [ ] **Step 2: Build `disabled_line` mirroring the existing `removed_line` block**
+
+After the existing `removed_line` block (around line 846), add:
+
+```bash
+          # Disabled stacks line
+          disabled_line=""
+          if [[ "$HAS_DISABLED" == "true" ]]; then
+            disabled_names=$(echo "$DISABLED_STACKS" | jq -r '. | join(", ")' 2>/dev/null || echo "")
+            if [[ -n "$disabled_names" ]]; then
+              disabled_line="🛑 **Disabled stacks:** $disabled_names"
+            fi
+          fi
+          {
+            echo "disabled_line<<EOF"
+            echo "$disabled_line"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 3: Add `disabled_line` to Discord embed description**
+
+In the `Send Discord notification` step (around line 858), in the `description:` multiline block, add a line after the existing `removed_line` interpolation (around line 867):
+
+```yaml
+          description: |
+            ${{ steps.status.outputs.description }}
+
+            ${{ steps.status.outputs.removed_line }}
+            ${{ steps.status.outputs.disabled_line }}
+
+            ${{ steps.status.outputs.deployment_needed == 'true' && format('**🔄 Pipeline Status**
+            {0}', steps.status.outputs.pipeline) || '' }}
+            ...
+```
+
+Note: the existing `removed_line` already handles the "empty when no removed stacks" case because the GitHub Actions `${{ ... }}` substitution preserves the empty string and the surrounding blank line is harmless. Same applies to `disabled_line`.
+
+- [ ] **Step 4: Pass `DISABLED_LINE` to `build-pr-comment.sh` env**
+
+In the step that invokes `build-pr-comment.sh` (around line 933, alongside `REMOVED_LINE`):
+
+```yaml
+          DISABLED_LINE: ${{ steps.status.outputs.disabled_line }}
+```
+
+- [ ] **Step 5: Validate**
+
+```bash
+actionlint .github/workflows/deploy.yml
+yamllint --strict .github/workflows/deploy.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "feat(notify): include disabled stacks in Discord and PR comment"
+```
+
+---
+
+## Task 9: Final lint + manual smoke verification plan
+
+**Files:** all touched files
+
+- [ ] **Step 1: Full repo lint pass**
+
+```bash
+shellcheck scripts/deployment/*.sh scripts/testing/*.sh scripts/testing/fixtures/*.sh
+actionlint .github/workflows/*.yml
+yamllint --strict .github/workflows/*.yml
+./scripts/testing/test-detect-stack-changes.sh
+```
+
+Expected: all pass. Test harness reports `Tests: 8  Passed: 8  Failed: 0`.
+
+- [ ] **Step 2: Write smoke-test runbook entry**
+
+This step does NOT execute the smoke test (that happens after merge against a real environment). Document the runbook in the commit message body so the human operator who deploys this can follow it:
+
+```
+After this change is merged and a caller-repo workflow picks up the new reusable-workflow SHA:
+
+1. Pick a low-stakes stack in docker-piwine-office (e.g. dozzle).
+2. touch dozzle/.disabled, commit, push to main.
+3. Wait for deploy workflow. Verify:
+   - Discord notification description includes "🛑 Disabled stacks: dozzle"
+   - PR comment (if from a PR) includes the same line
+   - On the host: docker compose ps shows no dozzle containers running
+   - /opt/compose/dozzle/compose.yaml still present on disk
+4. git rm dozzle/.disabled, commit, push.
+5. Verify: stack classified as "new" in deploy logs, containers running again, health check passes.
+```
+
+- [ ] **Step 3: Commit (final)**
+
+If any housekeeping diffs remain (e.g. shellcheck-discovered fixups), commit them:
+
+```bash
+git add -A
+git commit -m "chore: final lint pass for disabled-stacks feature" --allow-empty
+```
+
+If no diffs, skip the commit.
+
+---
+
+## Out of scope
+
+The spec's "Out of scope" section applies here verbatim: no reason strings, no central registry/dashboard, no per-env disable, no CLI tooling, no `.disabled` lint-trigger special-casing. If any of these are tempting during implementation, stop and consult the spec.
+
+## Risk + rollback
+
+If the deployed change misbehaves in production (e.g. mass false-positive teardowns), the rollback is the standard self-hosted runner rollback path documented in `compose-workflow/CLAUDE.md`: the caller repo's `deploy.yml` will rebase to the prior SHA pin of `owine/compose-workflow` (Renovate auto-bumps; manual revert is a single line). The bulk of risk is in Task 3/4 (detector logic) — those tasks gate the change via the test harness specifically to catch regressions before merge.

--- a/docs/superpowers/plans/2026-05-26-disabled-stacks.md
+++ b/docs/superpowers/plans/2026-05-26-disabled-stacks.md
@@ -382,7 +382,7 @@ Apply this concatenation pattern to all six detectors.
 
 - [ ] **Step 2: Update `detect_removed_stacks_gitdiff` body**
 
-Replace the existing `git diff --diff-filter=D` line and downstream pipeline with logic that:
+**Preserve the existing preamble inside the heredoc** (the `git fetch`, `TARGET_SHA=$(git rev-parse ...)`, and `git cat-file -e` SHA-existence guards). Replace only the trailing `git diff --diff-filter=D` pipeline at the end of the heredoc body. The new pipeline:
 1. Collects candidates from compose.yaml deletions (diff-filter `D`) AND `.disabled` additions (diff-filter `A`)
 2. For each candidate, emits only if `is_effectively_present_at_sha "$CURRENT_SHA" "$candidate"`
 
@@ -403,7 +403,7 @@ done
 
 - [ ] **Step 3: Update `detect_removed_stacks_tree` body**
 
-The current body computes `MISSING_IN_COMMIT` via filesystem comparison. Replace with:
+**Preserve the existing preamble** (`git fetch`, `TARGET_SHA=$(git rev-parse ...)`, and the `git cat-file -e $TARGET_SHA` existence guard). The current body computes `MISSING_IN_COMMIT` via filesystem comparison after that preamble — replace only the comparison logic with:
 
 ```bash
 # All directories that ever appeared at root in either tree or live filesystem.
@@ -497,7 +497,7 @@ Symmetric to Task 3. After this task all 8 fixtures should pass.
 
 - [ ] **Step 1: Update `detect_new_stacks_gitdiff` body**
 
-Replace the single `git diff --diff-filter=A` invocation with combined candidate collection + guard:
+**Preserve the existing preamble** (`git fetch`, `TARGET_SHA=$(git rev-parse ...)`, SHA-existence guards for both CURRENT and TARGET). Replace only the trailing `git diff --diff-filter=A` invocation with combined candidate collection + guard:
 
 ```bash
 {
@@ -515,7 +515,7 @@ done
 
 - [ ] **Step 2: Update `detect_new_stacks_tree` body**
 
-Replace `COMMIT_STACKS` / `SERVER_STACKS` / `comm -23` logic with:
+**Preserve the existing preamble** (`git fetch`, `TARGET_SHA`, SHA-existence guard). Replace only the `COMMIT_STACKS` / `SERVER_STACKS` / `comm -23` logic with:
 
 ```bash
 ALL_DIRS=$( {

--- a/docs/superpowers/specs/2026-05-26-disabled-stacks-design.md
+++ b/docs/superpowers/specs/2026-05-26-disabled-stacks-design.md
@@ -1,0 +1,139 @@
+# Disabled stacks via `.disabled` marker
+
+**Status:** Approved (design)
+**Date:** 2026-05-26
+**Scope:** `compose-workflow` reusable workflows (`deploy.yml`, `detect-stack-changes.sh`, optional notify paths)
+
+## Problem
+
+There is currently no way to temporarily disable a Docker Compose stack without deleting it from the repository. The only path to "stop running stack X" is to delete its `compose.yaml`, which loses local edits, history co-location, and configuration context. When you want to re-enable later, you restore from git, which is workable but awkward — and during the disabled window, the compose file is gone from the working tree entirely.
+
+We want a first-class disabled state that:
+
+1. Causes the deployment pipeline to run `docker compose down` against the stack on the disable transition (same teardown the workflow already runs for deleted stacks).
+2. Leaves the compose file and stack directory in place so they remain editable, lintable, and recoverable without git surgery.
+3. Allows a one-line re-enable that brings the stack back via the normal new-stack deploy path.
+4. Does not require changes to caller repositories beyond `touch <stack>/.disabled`.
+
+## Design
+
+### Marker file
+
+A stack is disabled when an empty `.disabled` file exists alongside its `compose.yaml`:
+
+```
+baikal/
+├── compose.yaml
+└── .disabled
+```
+
+Presence of the file is the entire signal. The file body is reserved for future use (e.g. a human-readable reason) but is unused today. Disabling is `touch <stack>/.disabled && git add <stack>/.disabled`. Re-enabling is `git rm <stack>/.disabled`.
+
+### Core predicate: "effectively present"
+
+A stack is **effectively present** at a given SHA iff:
+
+```
+compose.yaml exists  AND  .disabled does NOT exist
+```
+
+This single predicate replaces every "has `compose.yaml`" check inside `scripts/deployment/detect-stack-changes.sh`. With that substitution, the existing three-bucket classifier (removed / existing / new) yields exactly the right behavior for every transition:
+
+| Transition | CURRENT_SHA | TARGET_SHA | Classified as | Action |
+|---|---|---|---|---|
+| Disable | enabled | disabled | **removed** | `docker compose down` (teardown step at `deploy.yml:218`) |
+| Re-enable | disabled | enabled | **new** | `docker compose up --wait` (new-stack deploy step) |
+| Stay disabled | disabled | disabled | (excluded) | no-op |
+| Born disabled | absent | disabled | (excluded) | no-op |
+| Delete while disabled | disabled | absent | (excluded) | no-op (already torn down at disable time) |
+| Normal delete | enabled | absent | **removed** | `docker compose down` (unchanged) |
+| Normal add | absent | enabled | **new** | `docker compose up --wait` (unchanged) |
+| Normal update | enabled | enabled | **existing** | `docker compose up --wait` (unchanged) |
+
+The disable transition piggybacks on the removed-stack pathway. The teardown step reads compose files from the pre-reset live tree, so it tears down using the still-present `compose.yaml` — the `.disabled` marker does not interfere because teardown happens *before* `git reset --hard` updates the working tree.
+
+### Changes to `detect-stack-changes.sh`
+
+All detector functions are updated to use the effectively-present predicate. The aggregation and JSON-output layers are unchanged.
+
+- **`detect_removed_stacks_gitdiff`** — detect either `compose.yaml` deletion *or* `.disabled` addition between SHAs. Both signal a removed-effectively-present transition. Pattern becomes `'^[^/]+/(compose\.yaml|\.disabled)$'` with diff-filter `D` for compose.yaml and `A` for `.disabled`.
+- **`detect_removed_stacks_tree`** — compute effective-present sets on both sides (target SHA tree and live tree) using `git cat-file -e` for `compose.yaml` and `.disabled`. Removed set = present-in-live ∧ ¬present-in-target.
+- **`detect_removed_stacks_discovery`** — accept either `<stack>/compose.yaml` or `<stack>/.disabled` entries from the changed-files JSON. For `.disabled`, the file must be an *addition* (the changed-files action distinguishes adds from deletes; we filter accordingly).
+- **`detect_new_stacks_gitdiff`** — detect either `compose.yaml` addition *or* `.disabled` deletion between SHAs where the result is effectively-present in the target.
+- **`detect_new_stacks_tree`** — symmetric to removed: present-in-target ∧ ¬present-in-live.
+- **`detect_new_stacks_input`** — input filter already takes the effectively-present discover-stacks output, so this function works unchanged.
+
+### Changes to `deploy.yml` `prepare` job
+
+The `Discover stacks` step (deploy.yml:123–143) gains one filter: skip directories where `.disabled` is present. After change:
+
+```bash
+for dir in */; do
+  dir_name=$(basename "$dir")
+  if [[ -f "$dir/compose.yml" || -f "$dir/compose.yaml" ]] \
+     && [[ ! -f "$dir/.disabled" ]]; then
+    stacks+=("\"$dir_name\"")
+  fi
+done
+```
+
+A new `disabled_stacks` job output is emitted from the same step by enumerating directories that contain `.disabled` alongside a `compose.yaml`. This output drives visibility only — no deploy step branches on it.
+
+### Changes to notify and PR comment
+
+- `build-pr-comment.sh` — accept a new `--disabled-stacks` argument; render a "🛑 Disabled: foo, bar" line in the PR comment body when the list is non-empty, positioned adjacent to the existing "🗑️ Removed" line.
+- `deploy.yml` notify job — pass `prepare.outputs.disabled_stacks` through to the PR comment builder and include the same "🛑 Disabled" line in the Discord embed fields when non-empty.
+
+### Caller-repo workflow: no changes
+
+Lint discovery in caller repos does not filter `.disabled` — disabled stacks continue to receive YAML linting and `docker compose config` validation. This is intentional: keeps the disabled compose file from rotting silently between disable and re-enable.
+
+## Testing
+
+### Unit (script-level)
+
+Extend the existing testing harness under `scripts/testing/` with a fixture covering each transition row from the table above. For each row:
+
+1. Construct a two-SHA scenario in a throwaway git repo (CURRENT_SHA and TARGET_SHA with the appropriate `compose.yaml` / `.disabled` states).
+2. Run `detect-stack-changes.sh` against the scenario.
+3. Assert the resulting `removed_stacks`, `existing_stacks`, `new_stacks` JSON outputs match expected.
+
+Also run `shellcheck scripts/deployment/detect-stack-changes.sh` after edits.
+
+### Integration (workflow-level)
+
+`actionlint` and `yamllint --strict` on the modified `deploy.yml`.
+
+### Manual smoke test
+
+Pick one low-stakes stack (e.g. `dozzle` in `docker-piwine-office`):
+
+1. `touch dozzle/.disabled`, commit, push. Verify:
+   - Discord notification shows "🛑 Disabled: dozzle".
+   - On the host, `docker compose ps` shows no `dozzle` containers running.
+   - The `dozzle/compose.yaml` is still present in `/opt/compose/dozzle/`.
+2. `git rm dozzle/.disabled`, commit, push. Verify:
+   - Stack is classified as new (visible in deploy logs).
+   - Containers are running again after deploy completes.
+   - Health check passes (if dozzle is in the critical-stacks list — it is for piwine).
+
+## Out of scope (explicit YAGNI)
+
+- Reason strings or metadata in the marker file body.
+- A central registry or dashboard of disabled stacks across repos.
+- Per-environment disable semantics (use branches or repo-level config if this need arises).
+- CLI tooling — `touch` and `git rm` are sufficient.
+- Treating the marker file as a special-case "modification" for lint trigger purposes; existing path-based triggers cover it.
+
+## Files affected
+
+```
+compose-workflow/
+├── scripts/deployment/
+│   ├── detect-stack-changes.sh     # predicate update across 6 detector functions
+│   └── build-pr-comment.sh         # new --disabled-stacks arg + render line
+└── .github/workflows/
+    └── deploy.yml                   # discover-stacks filter, disabled_stacks output, notify wiring
+```
+
+No changes required in caller repositories (`docker-piwine`, `docker-piwine-office`, `docker-zendc`).

--- a/docs/superpowers/specs/2026-05-26-disabled-stacks-design.md
+++ b/docs/superpowers/specs/2026-05-26-disabled-stacks-design.md
@@ -52,16 +52,29 @@ This single predicate replaces every "has `compose.yaml`" check inside `scripts/
 
 The disable transition piggybacks on the removed-stack pathway. The teardown step reads compose files from the pre-reset live tree, so it tears down using the still-present `compose.yaml` — the `.disabled` marker does not interfere because teardown happens *before* `git reset --hard` updates the working tree.
 
+**Operational assumption:** The "delete while disabled" row is a no-op because the design assumes the stack was already torn down at the prior disable event. If you push a single commit that goes straight from enabled → absent (skipping the disabled state), the existing "normal delete" row handles it. The pathological case is pushing one commit that disables a stack and a second commit that deletes the directory *before the disable deploy has run* — there, the disable transition gets collapsed into a delete, but the teardown still fires correctly because the live tree's pre-reset state still has `compose.yaml` without `.disabled`, which the removed-tree detector picks up via "live-effective ∖ target-effective."
+
 ### Changes to `detect-stack-changes.sh`
 
 All detector functions are updated to use the effectively-present predicate. The aggregation and JSON-output layers are unchanged.
 
-- **`detect_removed_stacks_gitdiff`** — detect either `compose.yaml` deletion *or* `.disabled` addition between SHAs. Both signal a removed-effectively-present transition. Pattern becomes `'^[^/]+/(compose\.yaml|\.disabled)$'` with diff-filter `D` for compose.yaml and `A` for `.disabled`.
-- **`detect_removed_stacks_tree`** — compute effective-present sets on both sides (target SHA tree and live tree) using `git cat-file -e` for `compose.yaml` and `.disabled`. Removed set = present-in-live ∧ ¬present-in-target.
-- **`detect_removed_stacks_discovery`** — accept either `<stack>/compose.yaml` or `<stack>/.disabled` entries from the changed-files JSON. For `.disabled`, the file must be an *addition* (the changed-files action distinguishes adds from deletes; we filter accordingly).
-- **`detect_new_stacks_gitdiff`** — detect either `compose.yaml` addition *or* `.disabled` deletion between SHAs where the result is effectively-present in the target.
-- **`detect_new_stacks_tree`** — symmetric to removed: present-in-target ∧ ¬present-in-live.
-- **`detect_new_stacks_input`** — input filter already takes the effectively-present discover-stacks output, so this function works unchanged.
+**Critical guard for both directions:** every detector must classify a stack only when the effective-presence state *actually transitioned* between CURRENT and TARGET. Naive pattern matching on file-change diffs is insufficient because two pathological rows from the transition table would otherwise leak into the wrong bucket:
+
+- **Born disabled (absent → disabled)**: a single commit adds both `compose.yaml` and `.disabled`. A naive removed detector keyed on "`.disabled` addition" would flag this for teardown, but the stack was never effectively present in CURRENT and there is nothing to tear down.
+- **Delete while disabled (disabled → absent)**: a naive removed detector keyed on "`compose.yaml` deletion" would flag this, but the stack was already disabled (and therefore already torn down at the prior disable event).
+
+Both cases must be excluded. The fix is to gate every removed candidate on **effectively-present in CURRENT_SHA** and every new candidate on **effectively-present in TARGET_SHA**, evaluated via `git cat-file -e` against the respective tree.
+
+Detector-by-detector changes:
+
+- **`detect_removed_stacks_gitdiff`** — find candidate stack names from diff entries matching `'^[^/]+/(compose\.yaml|\.disabled)$'` (compose.yaml with diff-filter `D`, `.disabled` with diff-filter `A`). For each candidate, emit it only if it was effectively-present in CURRENT_SHA: `git cat-file -e $CURRENT_SHA:<stack>/compose.yaml` succeeds AND `git cat-file -e $CURRENT_SHA:<stack>/.disabled` fails.
+- **`detect_removed_stacks_tree`** — compute the effective-present set on each side. Live side: directory contains `compose.yaml` AND not `.disabled` on the filesystem. Target side: `git cat-file -e $TARGET_SHA:<dir>/compose.yaml` AND not `git cat-file -e $TARGET_SHA:<dir>/.disabled`. Removed set = live-effective ∖ target-effective.
+- **`detect_removed_stacks_discovery`** — accept candidate stack names from changed-files JSON entries matching either `<stack>/compose.yaml` (deletion) or `<stack>/.disabled` (addition). The action distinguishes adds from deletes via the `deleted_files` / `added_files` outputs; the workflow already passes deleted only, so add a second pass for added `.disabled` files. Apply the same effectively-present-in-CURRENT guard before emitting.
+- **`detect_new_stacks_gitdiff`** — find candidates from `compose.yaml` additions (diff-filter `A`) and `.disabled` deletions (diff-filter `D`). Emit only if effectively-present in TARGET_SHA: `git cat-file -e $TARGET_SHA:<stack>/compose.yaml` succeeds AND `git cat-file -e $TARGET_SHA:<stack>/.disabled` fails.
+- **`detect_new_stacks_tree`** — symmetric to removed-tree: target-effective ∖ live-effective.
+- **`detect_new_stacks_input`** — input filter takes the (already disabled-filtered) discover-stacks output, so this function works unchanged.
+
+Workflow inputs: the discovery branch must also receive added-files JSON, not just deleted. Update the `Detect stack changes` step in `deploy.yml` (around line 145) to pass both `deleted_files` and `added_files` outputs from `tj-actions/changed-files`; the script gains a `--added-files` flag mirroring `--removed-files`.
 
 ### Changes to `deploy.yml` `prepare` job
 
@@ -77,7 +90,7 @@ for dir in */; do
 done
 ```
 
-A new `disabled_stacks` job output is emitted from the same step by enumerating directories that contain `.disabled` alongside a `compose.yaml`. This output drives visibility only — no deploy step branches on it.
+A new `disabled_stacks` job output is emitted from the same step as a JSON array (consistent with the existing `removed_stacks` / `existing_stacks` / `new_stacks` outputs), enumerating directories that contain `.disabled` alongside a `compose.yaml`. This output drives visibility only — no deploy step branches on it.
 
 ### Changes to notify and PR comment
 
@@ -86,7 +99,7 @@ A new `disabled_stacks` job output is emitted from the same step by enumerating 
 
 ### Caller-repo workflow: no changes
 
-Lint discovery in caller repos does not filter `.disabled` — disabled stacks continue to receive YAML linting and `docker compose config` validation. This is intentional: keeps the disabled compose file from rotting silently between disable and re-enable.
+Lint discovery in caller repos does not filter `.disabled` — disabled stacks continue to receive YAML linting and `docker compose config` validation. This is intentional: keeps the disabled compose file from rotting silently between disable and re-enable. Future contributors tempted to "fix" the caller-side discovery snippet (e.g. the example in the root `CLAUDE.md`) for consistency with the deploy-side filter should be deterred — the asymmetry is by design.
 
 ## Testing
 
@@ -97,6 +110,8 @@ Extend the existing testing harness under `scripts/testing/` with a fixture cove
 1. Construct a two-SHA scenario in a throwaway git repo (CURRENT_SHA and TARGET_SHA with the appropriate `compose.yaml` / `.disabled` states).
 2. Run `detect-stack-changes.sh` against the scenario.
 3. Assert the resulting `removed_stacks`, `existing_stacks`, `new_stacks` JSON outputs match expected.
+
+The fixture set must explicitly include a **born-disabled** row: a commit that adds both `compose.yaml` and `.disabled` simultaneously, asserted to produce empty removed/existing/new — this catches regressions of the effectively-present-in-CURRENT guard, which is the failure mode where the discovery detector or gitdiff detector would naively flag the `.disabled` addition as a removal. Similarly include a **delete-while-disabled** row to catch the symmetric naive-removal regression.
 
 Also run `shellcheck scripts/deployment/detect-stack-changes.sh` after edits.
 

--- a/scripts/deployment/build-pr-comment.sh
+++ b/scripts/deployment/build-pr-comment.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 : "${DESCRIPTION:=}"
 : "${PIPELINE:=}"
 : "${REMOVED_LINE:=}"
+: "${DISABLED_LINE:=}"
 
 # Sanitize COMMIT_SUBJECT — it's user-controlled (PR commit message).
 # Strip newlines/CR, truncate to 120 chars, replace backticks (which would break
@@ -53,6 +54,11 @@ fi
 # Removed-stacks line (only when present).
 if [[ -n "$REMOVED_LINE" ]]; then
   printf '%s\n\n' "$REMOVED_LINE"
+fi
+
+# Disabled-stacks line (only when present).
+if [[ -n "$DISABLED_LINE" ]]; then
+  printf '%s\n\n' "$DISABLED_LINE"
 fi
 
 # Pipeline pills — collapsed on success, raw on any failure.

--- a/scripts/deployment/detect-stack-changes.sh
+++ b/scripts/deployment/detect-stack-changes.sh
@@ -264,9 +264,17 @@ detect_new_stacks_gitdiff() {
     exit 1
   fi
 
-  git diff --diff-filter=A --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null | \
-    grep -E '^[^/]+/compose\.yaml$' | \
-    sed 's|/compose\.yaml||' || echo ""
+  {
+    git diff --diff-filter=A --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null \
+      | grep -E '^[^/]+/compose\.yaml$' | sed 's|/compose\.yaml||' || true
+    git diff --diff-filter=D --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null \
+      | grep -E '^[^/]+/\.disabled$' | sed 's|/\.disabled||' || true
+  } | sort -u | while read -r candidate; do
+    [[ -z "$candidate" ]] && continue
+    if is_effectively_present_at_sha "$TARGET_SHA" "$candidate"; then
+      echo "$candidate"
+    fi
+  done
 DETECT_NEW_EOF
 )"
 
@@ -298,19 +306,17 @@ detect_new_stacks_tree() {
     exit 1
   fi
 
-  COMMIT_STACKS=$(git ls-tree --name-only "$TARGET_SHA" 2>/dev/null | while read -r dir; do
-    if git cat-file -e "$TARGET_SHA:$dir/compose.yaml" 2>/dev/null; then
+  ALL_DIRS=$( {
+    git ls-tree --name-only "$TARGET_SHA" 2>/dev/null
+    find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \;
+  } | sort -u )
+
+  for dir in $ALL_DIRS; do
+    if is_effectively_present_at_sha "$TARGET_SHA" "$dir" \
+       && ! is_effectively_present_on_disk "$LIVE_REPO_PATH" "$dir"; then
       echo "$dir"
     fi
-  done | sort)
-
-  SERVER_STACKS=$(find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \; 2>/dev/null | while read -r dir; do
-    if [ -f "$LIVE_REPO_PATH/$dir/compose.yaml" ]; then
-      echo "$dir"
-    fi
-  done | sort)
-
-  comm -23 <(echo "$COMMIT_STACKS") <(echo "$SERVER_STACKS")
+  done
 DETECT_NEW_TREE_EOF
 )"
 

--- a/scripts/deployment/detect-stack-changes.sh
+++ b/scripts/deployment/detect-stack-changes.sh
@@ -25,11 +25,9 @@ CURRENT_SHA=""
 TARGET_REF=""
 INPUT_STACKS="[]"
 REMOVED_FILES="[]"
-# shellcheck disable=SC2034  # consumed by detect_removed_stacks_discovery in a later task
 ADDED_FILES="[]"
 LIVE_REPO_PATH="${LIVE_REPO_PATH:-}"
 
-# shellcheck disable=SC2034  # ADDED_FILES consumed by detect_removed_stacks_discovery in a later task
 while [[ $# -gt 0 ]]; do
   case $1 in
     --current-sha)      CURRENT_SHA="$2"; shift 2 ;;
@@ -52,6 +50,26 @@ if [[ -z "$LIVE_REPO_PATH" ]]; then
   log_error "--live-repo-path (or LIVE_REPO_PATH env) is required"
   exit 1
 fi
+
+# HELPER_FUNCS: shared bash helpers prepended into each detector's heredoc body.
+# Defined once script-side so the same logic powers all six detectors without
+# duplicating the function bodies inside each heredoc.
+# shellcheck disable=SC2016  # single quotes intentional - body is injected into a subshell heredoc verbatim
+HELPER_FUNCS='
+is_effectively_present_at_sha() {
+  local sha="$1" stack="$2"
+  git cat-file -e "$sha:$stack/compose.yaml" 2>/dev/null || return 1
+  if git cat-file -e "$sha:$stack/.disabled" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+is_effectively_present_on_disk() {
+  local root="$1" stack="$2"
+  [[ -f "$root/$stack/compose.yaml" ]] || return 1
+  [[ ! -f "$root/$stack/.disabled" ]]
+}
+'
 
 # run_local: dispatches a bash script body (stdin) with LIVE_REPO_PATH
 # propagated as an env var, so heredoc bodies can reference "$LIVE_REPO_PATH"
@@ -96,7 +114,7 @@ detect_removed_stacks_gitdiff() {
   log_info "Running git diff detection for removed stacks..."
 
   local detect_script
-  detect_script=$(cat << 'DETECT_EOF'
+  detect_script="$HELPER_FUNCS"$'\n'"$(cat << 'DETECT_EOF'
   set -e
   CURRENT_SHA="$1"
   TARGET_REF="$2"
@@ -123,11 +141,19 @@ detect_removed_stacks_gitdiff() {
     exit 1
   fi
 
-  git diff --diff-filter=D --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null | \
-    grep -E '^[^/]+/compose\.yaml$' | \
-    sed 's|/compose\.yaml||' || echo ""
+  {
+    git diff --diff-filter=D --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null \
+      | grep -E '^[^/]+/compose\.yaml$' | sed 's|/compose\.yaml||' || true
+    git diff --diff-filter=A --name-only "$CURRENT_SHA" "$TARGET_SHA" 2>/dev/null \
+      | grep -E '^[^/]+/\.disabled$' | sed 's|/\.disabled||' || true
+  } | sort -u | while read -r candidate; do
+    [[ -z "$candidate" ]] && continue
+    if is_effectively_present_at_sha "$CURRENT_SHA" "$candidate"; then
+      echo "$candidate"
+    fi
+  done
 DETECT_EOF
-  )
+)"
 
   echo "$detect_script" | run_local "$current_sha" "$target_ref"
 }
@@ -137,7 +163,7 @@ detect_removed_stacks_tree() {
   log_info "Running tree comparison detection for removed stacks..."
 
   local detect_script
-  detect_script=$(cat << 'DETECT_TREE_EOF'
+  detect_script="$HELPER_FUNCS"$'\n'"$(cat << 'DETECT_TREE_EOF'
   set -e
   TARGET_REF="$1"
 
@@ -158,40 +184,49 @@ detect_removed_stacks_tree() {
     exit 1
   fi
 
-  COMMIT_DIRS=$(git ls-tree --name-only "$TARGET_SHA" 2>/dev/null | sort)
-  SERVER_DIRS=$(find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \; 2>/dev/null | sort)
-  MISSING_IN_COMMIT=$(comm -13 <(echo "$COMMIT_DIRS") <(echo "$SERVER_DIRS"))
+  ALL_DIRS=$( {
+    git ls-tree --name-only "$TARGET_SHA" 2>/dev/null
+    find "$LIVE_REPO_PATH" -maxdepth 1 -mindepth 1 -type d ! -name '.*' -exec basename {} \;
+  } | sort -u )
 
-  for dir in $MISSING_IN_COMMIT; do
-    if [ -f "$LIVE_REPO_PATH/$dir/compose.yaml" ]; then
+  for dir in $ALL_DIRS; do
+    if is_effectively_present_on_disk "$LIVE_REPO_PATH" "$dir" \
+       && ! is_effectively_present_at_sha "$TARGET_SHA" "$dir"; then
       echo "$dir"
     fi
   done
 DETECT_TREE_EOF
-  )
+)"
 
   echo "$detect_script" | run_local "$target_ref"
 }
 
 detect_removed_stacks_discovery() {
-  local removed_files_json="$1"
+  local removed_files_json="$1" added_files_json="$2" current_sha="$3"
   log_info "Running discovery analysis detection for removed stacks..."
-
-  # Base64 encode JSON to avoid shell glob expansion issues
-  local removed_files_b64
-  removed_files_b64=$(echo -n "$removed_files_json" | base64 -w 0 2>/dev/null || echo -n "$removed_files_json" | base64)
+  local removed_b64 added_b64
+  removed_b64=$(echo -n "$removed_files_json" | base64 -w 0 2>/dev/null || echo -n "$removed_files_json" | base64)
+  added_b64=$(echo -n "$added_files_json" | base64 -w 0 2>/dev/null || echo -n "$added_files_json" | base64)
 
   local detect_script
-  detect_script=$(cat << 'DETECT_DISCOVERY_EOF'
+  detect_script="$HELPER_FUNCS"$'\n'"$(cat << 'DETECT_DISCOVERY_EOF'
   set -e
-  REMOVED_FILES_JSON=$(echo "$1" | base64 -d)
-  echo "$REMOVED_FILES_JSON" | jq -r '.[]' 2>/dev/null | \
-    grep -E '^[^/]+/compose\.yaml$' | \
-    sed 's|/compose\.yaml||' || echo ""
+  CURRENT_SHA="$3"
+  REMOVED_JSON=$(echo "$1" | base64 -d)
+  ADDED_JSON=$(echo "$2" | base64 -d)
+  cd "$LIVE_REPO_PATH"
+  {
+    echo "$REMOVED_JSON" | jq -r '.[]?' | grep -E '^[^/]+/compose\.yaml$' | sed 's|/compose\.yaml||' || true
+    echo "$ADDED_JSON"   | jq -r '.[]?' | grep -E '^[^/]+/\.disabled$'    | sed 's|/\.disabled||'    || true
+  } | sort -u | while read -r candidate; do
+    [[ -z "$candidate" ]] && continue
+    if is_effectively_present_at_sha "$CURRENT_SHA" "$candidate"; then
+      echo "$candidate"
+    fi
+  done
 DETECT_DISCOVERY_EOF
-  )
-
-  echo "$detect_script" | run_local "$removed_files_b64"
+)"
+  echo "$detect_script" | run_local "$removed_b64" "$added_b64" "$current_sha"
 }
 
 # ================================================================
@@ -203,7 +238,7 @@ detect_new_stacks_gitdiff() {
   log_info "Running git diff detection for new stacks..."
 
   local detect_script
-  detect_script=$(cat << 'DETECT_NEW_EOF'
+  detect_script="$HELPER_FUNCS"$'\n'"$(cat << 'DETECT_NEW_EOF'
   set -e
   CURRENT_SHA="$1"
   TARGET_REF="$2"
@@ -233,7 +268,7 @@ detect_new_stacks_gitdiff() {
     grep -E '^[^/]+/compose\.yaml$' | \
     sed 's|/compose\.yaml||' || echo ""
 DETECT_NEW_EOF
-  )
+)"
 
   echo "$detect_script" | run_local "$current_sha" "$target_ref"
 }
@@ -243,7 +278,7 @@ detect_new_stacks_tree() {
   log_info "Running tree comparison detection for new stacks..."
 
   local detect_script
-  detect_script=$(cat << 'DETECT_NEW_TREE_EOF'
+  detect_script="$HELPER_FUNCS"$'\n'"$(cat << 'DETECT_NEW_TREE_EOF'
   set -e
   TARGET_REF="$1"
 
@@ -277,7 +312,7 @@ detect_new_stacks_tree() {
 
   comm -23 <(echo "$COMMIT_STACKS") <(echo "$SERVER_STACKS")
 DETECT_NEW_TREE_EOF
-  )
+)"
 
   echo "$detect_script" | run_local "$target_ref"
 }
@@ -332,13 +367,7 @@ REMOVED_DISCOVERY_EXIT=0
 REMOVED_GITDIFF=$(detect_removed_stacks_gitdiff "$CURRENT_SHA" "$TARGET_REF") || REMOVED_GITDIFF_EXIT=$?
 REMOVED_TREE=$(detect_removed_stacks_tree "$TARGET_REF") || REMOVED_TREE_EXIT=$?
 
-if [ "$REMOVED_FILES" = "[]" ] || [ -z "$REMOVED_FILES" ]; then
-  log_info "No removed files detected - skipping removed discovery analysis"
-  REMOVED_DISCOVERY=""
-  REMOVED_DISCOVERY_EXIT=0
-else
-  REMOVED_DISCOVERY=$(detect_removed_stacks_discovery "$REMOVED_FILES") || REMOVED_DISCOVERY_EXIT=$?
-fi
+REMOVED_DISCOVERY=$(detect_removed_stacks_discovery "$REMOVED_FILES" "$ADDED_FILES" "$CURRENT_SHA") || REMOVED_DISCOVERY_EXIT=$?
 
 NEW_GITDIFF_EXIT=0
 NEW_TREE_EXIT=0

--- a/scripts/deployment/detect-stack-changes.sh
+++ b/scripts/deployment/detect-stack-changes.sh
@@ -25,14 +25,18 @@ CURRENT_SHA=""
 TARGET_REF=""
 INPUT_STACKS="[]"
 REMOVED_FILES="[]"
+# shellcheck disable=SC2034  # consumed by detect_removed_stacks_discovery in a later task
+ADDED_FILES="[]"
 LIVE_REPO_PATH="${LIVE_REPO_PATH:-}"
 
+# shellcheck disable=SC2034  # ADDED_FILES consumed by detect_removed_stacks_discovery in a later task
 while [[ $# -gt 0 ]]; do
   case $1 in
     --current-sha)      CURRENT_SHA="$2"; shift 2 ;;
     --target-ref)       TARGET_REF="$2"; shift 2 ;;
     --input-stacks)     INPUT_STACKS="$2"; shift 2 ;;
     --removed-files)    REMOVED_FILES="$2"; shift 2 ;;
+    --added-files)      ADDED_FILES="$2"; shift 2 ;;
     --live-repo-path)   LIVE_REPO_PATH="$2"; shift 2 ;;
     *)
       log_error "Unknown argument: $1"

--- a/scripts/testing/fixtures/transition-cases.sh
+++ b/scripts/testing/fixtures/transition-cases.sh
@@ -3,8 +3,10 @@
 # Each function: builds scenario, runs script, asserts expected classification.
 
 case_normal_add() {
-  local wd; wd=$(mktemp -d)
-  read -r current target <<<"$(build_scenario "$wd" _setup_empty _add_foo_enabled)"
+  local wd; wd=$(mktemp -d -p "$TMPROOT")
+  local shas; shas=$(build_scenario "$wd" _setup_empty _add_foo_enabled)
+  local current target
+  read -r current target <<<"$shas"
   local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '[]' '["foo/compose.yaml"]')
   assert_classifications "normal_add" '[]' '[]' '["foo"]' "$out"
 }
@@ -14,8 +16,10 @@ _setup_empty() { :; }
 _add_foo_enabled() { mkdir -p foo; echo 'services: {a: {image: nginx}}' > foo/compose.yaml; }
 
 case_normal_delete() {
-  local wd; wd=$(mktemp -d)
-  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _delete_foo)"
+  local wd; wd=$(mktemp -d -p "$TMPROOT")
+  local shas; shas=$(build_scenario "$wd" _add_foo_enabled _delete_foo)
+  local current target
+  read -r current target <<<"$shas"
   local out; out=$(run_detect "$wd" "$current" "$target" '[]' '["foo/compose.yaml"]' '[]')
   assert_classifications "normal_delete" '["foo"]' '[]' '[]' "$out"
 }
@@ -23,8 +27,10 @@ case_normal_delete() {
 _delete_foo() { rm -rf foo; }
 
 case_normal_update() {
-  local wd; wd=$(mktemp -d)
-  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _modify_foo)"
+  local wd; wd=$(mktemp -d -p "$TMPROOT")
+  local shas; shas=$(build_scenario "$wd" _add_foo_enabled _modify_foo)
+  local current target
+  read -r current target <<<"$shas"
   local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '[]' '[]')
   assert_classifications "normal_update" '[]' '["foo"]' '[]' "$out"
 }
@@ -32,8 +38,10 @@ case_normal_update() {
 _modify_foo() { echo 'services: {a: {image: nginx:1.27}}' > foo/compose.yaml; }
 
 case_disable() {
-  local wd; wd=$(mktemp -d)
-  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _disable_foo)"
+  local wd; wd=$(mktemp -d -p "$TMPROOT")
+  local shas; shas=$(build_scenario "$wd" _add_foo_enabled _disable_foo)
+  local current target
+  read -r current target <<<"$shas"
   # Input stacks excludes foo because the discover step (workflow-side) filters
   # .disabled-bearing dirs. Simulate that here.
   local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '["foo/.disabled"]')
@@ -43,8 +51,10 @@ case_disable() {
 _disable_foo() { touch foo/.disabled; }
 
 case_re_enable() {
-  local wd; wd=$(mktemp -d)
-  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _enable_foo)"
+  local wd; wd=$(mktemp -d -p "$TMPROOT")
+  local shas; shas=$(build_scenario "$wd" _add_foo_disabled _enable_foo)
+  local current target
+  read -r current target <<<"$shas"
   local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '["foo/.disabled"]' '[]')
   assert_classifications "re_enable" '[]' '[]' '["foo"]' "$out"
 }
@@ -56,8 +66,10 @@ _add_foo_disabled() {
 _enable_foo() { rm foo/.disabled; }
 
 case_stay_disabled() {
-  local wd; wd=$(mktemp -d)
-  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _noop)"
+  local wd; wd=$(mktemp -d -p "$TMPROOT")
+  local shas; shas=$(build_scenario "$wd" _add_foo_disabled _noop)
+  local current target
+  read -r current target <<<"$shas"
   local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '[]')
   assert_classifications "stay_disabled" '[]' '[]' '[]' "$out"
 }
@@ -65,16 +77,20 @@ case_stay_disabled() {
 _noop() { :; }
 
 case_born_disabled() {
-  local wd; wd=$(mktemp -d)
-  read -r current target <<<"$(build_scenario "$wd" _setup_empty _add_foo_disabled)"
+  local wd; wd=$(mktemp -d -p "$TMPROOT")
+  local shas; shas=$(build_scenario "$wd" _setup_empty _add_foo_disabled)
+  local current target
+  read -r current target <<<"$shas"
   # Both files appear as added; this is the regression case for the guard.
   local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '["foo/compose.yaml","foo/.disabled"]')
   assert_classifications "born_disabled" '[]' '[]' '[]' "$out"
 }
 
 case_delete_while_disabled() {
-  local wd; wd=$(mktemp -d)
-  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _delete_foo)"
+  local wd; wd=$(mktemp -d -p "$TMPROOT")
+  local shas; shas=$(build_scenario "$wd" _add_foo_disabled _delete_foo)
+  local current target
+  read -r current target <<<"$shas"
   local out; out=$(run_detect "$wd" "$current" "$target" '[]' '["foo/compose.yaml","foo/.disabled"]' '[]')
   assert_classifications "delete_while_disabled" '[]' '[]' '[]' "$out"
 }

--- a/scripts/testing/fixtures/transition-cases.sh
+++ b/scripts/testing/fixtures/transition-cases.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Transition table scenarios for detect-stack-changes.sh tests.
+# Each function: builds scenario, runs script, asserts expected classification.
+
+case_normal_add() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _setup_empty _add_foo_enabled)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '[]' '["foo/compose.yaml"]')
+  assert_classifications "normal_add" '[]' '[]' '["foo"]' "$out"
+}
+# shellcheck disable=SC2317  # invoked indirectly via build_scenario
+_setup_empty() { :; }
+# shellcheck disable=SC2317  # invoked indirectly via build_scenario
+_add_foo_enabled() { mkdir -p foo; echo 'services: {a: {image: nginx}}' > foo/compose.yaml; }
+
+case_normal_delete() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _delete_foo)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '["foo/compose.yaml"]' '[]')
+  assert_classifications "normal_delete" '["foo"]' '[]' '[]' "$out"
+}
+# shellcheck disable=SC2317  # invoked indirectly via build_scenario
+_delete_foo() { rm -rf foo; }
+
+case_normal_update() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _modify_foo)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '[]' '[]')
+  assert_classifications "normal_update" '[]' '["foo"]' '[]' "$out"
+}
+# shellcheck disable=SC2317  # invoked indirectly via build_scenario
+_modify_foo() { echo 'services: {a: {image: nginx:1.27}}' > foo/compose.yaml; }
+
+case_disable() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_enabled _disable_foo)"
+  # Input stacks excludes foo because the discover step (workflow-side) filters
+  # .disabled-bearing dirs. Simulate that here.
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '["foo/.disabled"]')
+  assert_classifications "disable" '["foo"]' '[]' '[]' "$out"
+}
+# shellcheck disable=SC2317  # invoked indirectly via build_scenario
+_disable_foo() { touch foo/.disabled; }
+
+case_re_enable() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _enable_foo)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '["foo"]' '["foo/.disabled"]' '[]')
+  assert_classifications "re_enable" '[]' '[]' '["foo"]' "$out"
+}
+# shellcheck disable=SC2317  # invoked indirectly via build_scenario
+_add_foo_disabled() {
+  mkdir -p foo; echo 'services: {a: {image: nginx}}' > foo/compose.yaml; touch foo/.disabled;
+}
+# shellcheck disable=SC2317  # invoked indirectly via build_scenario
+_enable_foo() { rm foo/.disabled; }
+
+case_stay_disabled() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _noop)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '[]')
+  assert_classifications "stay_disabled" '[]' '[]' '[]' "$out"
+}
+# shellcheck disable=SC2317  # invoked indirectly via build_scenario
+_noop() { :; }
+
+case_born_disabled() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _setup_empty _add_foo_disabled)"
+  # Both files appear as added; this is the regression case for the guard.
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '[]' '["foo/compose.yaml","foo/.disabled"]')
+  assert_classifications "born_disabled" '[]' '[]' '[]' "$out"
+}
+
+case_delete_while_disabled() {
+  local wd; wd=$(mktemp -d)
+  read -r current target <<<"$(build_scenario "$wd" _add_foo_disabled _delete_foo)"
+  local out; out=$(run_detect "$wd" "$current" "$target" '[]' '["foo/compose.yaml","foo/.disabled"]' '[]')
+  assert_classifications "delete_while_disabled" '[]' '[]' '[]' "$out"
+}
+
+run_all_cases() {
+  case_normal_add
+  case_normal_delete
+  case_normal_update
+  case_disable
+  case_re_enable
+  case_stay_disabled
+  case_born_disabled
+  case_delete_while_disabled
+}

--- a/scripts/testing/test-detect-stack-changes.sh
+++ b/scripts/testing/test-detect-stack-changes.sh
@@ -7,7 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DETECT_SCRIPT="$REPO_ROOT/scripts/deployment/detect-stack-changes.sh"
 
-# shellcheck source=fixtures/transition-cases.sh
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=scripts/testing/fixtures/transition-cases.sh
 source "$SCRIPT_DIR/fixtures/transition-cases.sh"
 
 PASS=0
@@ -29,7 +30,7 @@ build_scenario() {
     git config user.name "Test"
     "$current_fn"
     git add -A
-    git commit -q -m "current"
+    git commit -q --allow-empty -m "current"
     CURRENT_SHA=$(git rev-parse HEAD)
     "$target_fn"
     git add -A
@@ -65,7 +66,8 @@ run_detect() {
 # Read a GITHUB_OUTPUT-format key
 read_output() {
   local file="$1" key="$2"
-  grep "^${key}=" "$file" | head -1 | cut -d= -f2-
+  # Tolerate missing key: grep returns 1 with pipefail otherwise kills caller.
+  grep "^${key}=" "$file" 2>/dev/null | head -1 | cut -d= -f2- || true
 }
 
 # assert <case_name> <expected_removed_json> <expected_existing_json> \

--- a/scripts/testing/test-detect-stack-changes.sh
+++ b/scripts/testing/test-detect-stack-changes.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/deployment/detect-stack-changes.sh
+# Builds throwaway git repos per scenario, runs the script, asserts JSON outputs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DETECT_SCRIPT="$REPO_ROOT/scripts/deployment/detect-stack-changes.sh"
+
+# shellcheck source=fixtures/transition-cases.sh
+source "$SCRIPT_DIR/fixtures/transition-cases.sh"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# build_scenario <workdir> <current_setup_fn> <target_setup_fn>
+# Creates a git repo at <workdir> with two commits. Each setup fn is called
+# with the workdir as CWD and performs file mutations representing one SHA.
+# Returns CURRENT_SHA and TARGET_SHA via globals.
+build_scenario() {
+  local workdir="$1" current_fn="$2" target_fn="$3"
+  rm -rf "$workdir"
+  mkdir -p "$workdir"
+  (
+    cd "$workdir"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    "$current_fn"
+    git add -A
+    git commit -q -m "current"
+    CURRENT_SHA=$(git rev-parse HEAD)
+    "$target_fn"
+    git add -A
+    # Allow empty in case target_fn only deletes
+    git commit -q --allow-empty -m "target"
+    TARGET_SHA=$(git rev-parse HEAD)
+    echo "$CURRENT_SHA $TARGET_SHA"
+  )
+}
+
+# run_detect <workdir> <current_sha> <target_sha> <input_stacks_json> \
+#            [<removed_files_json>] [<added_files_json>]
+# Runs the detect script with GITHUB_OUTPUT redirected to a temp file,
+# returns the file path (caller parses it).
+run_detect() {
+  local workdir="$1" current="$2" target="$3" input="$4"
+  local removed="${5:-[]}" added="${6:-[]}"
+  local out
+  out=$(mktemp)
+  GITHUB_OUTPUT="$out" "$DETECT_SCRIPT" \
+    --current-sha "$current" \
+    --target-ref "$target" \
+    --live-repo-path "$workdir" \
+    --input-stacks "$input" \
+    --removed-files "$removed" \
+    --added-files "$added" \
+    >/dev/null 2>&1 || {
+      echo "::detect-script-failed::" >> "$out"
+    }
+  echo "$out"
+}
+
+# Read a GITHUB_OUTPUT-format key
+read_output() {
+  local file="$1" key="$2"
+  grep "^${key}=" "$file" | head -1 | cut -d= -f2-
+}
+
+# assert <case_name> <expected_removed_json> <expected_existing_json> \
+#        <expected_new_json> <output_file>
+assert_classifications() {
+  local name="$1" exp_removed="$2" exp_existing="$3" exp_new="$4" out="$5"
+  local got_removed got_existing got_new
+  got_removed=$(read_output "$out" removed_stacks)
+  got_existing=$(read_output "$out" existing_stacks)
+  got_new=$(read_output "$out" new_stacks)
+
+  if [[ "$got_removed" == "$exp_removed" \
+     && "$got_existing" == "$exp_existing" \
+     && "$got_new" == "$exp_new" ]]; then
+    echo "✅ $name"
+    PASS=$((PASS+1))
+  else
+    echo "❌ $name"
+    echo "   removed:  got=$got_removed  want=$exp_removed"
+    echo "   existing: got=$got_existing want=$exp_existing"
+    echo "   new:      got=$got_new      want=$exp_new"
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+  fi
+}
+
+# Run all transition test cases (defined in fixtures file).
+run_all_cases
+
+echo ""
+echo "========================================"
+echo "Tests: $((PASS+FAIL))  Passed: $PASS  Failed: $FAIL"
+echo "========================================"
+if [[ $FAIL -gt 0 ]]; then
+  printf 'Failures:\n'
+  printf '  - %s\n' "${FAILURES[@]}"
+  exit 1
+fi

--- a/scripts/testing/test-detect-stack-changes.sh
+++ b/scripts/testing/test-detect-stack-changes.sh
@@ -7,6 +7,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DETECT_SCRIPT="$REPO_ROOT/scripts/deployment/detect-stack-changes.sh"
 
+TMPROOT=$(mktemp -d -t detect-tests.XXXXXX)
+export TMPROOT
+trap 'rm -rf "$TMPROOT"' EXIT
+
 # shellcheck source-path=SCRIPTDIR
 # shellcheck source=scripts/testing/fixtures/transition-cases.sh
 source "$SCRIPT_DIR/fixtures/transition-cases.sh"
@@ -16,9 +20,9 @@ FAIL=0
 FAILURES=()
 
 # build_scenario <workdir> <current_setup_fn> <target_setup_fn>
-# Creates a git repo at <workdir> with two commits. Each setup fn is called
-# with the workdir as CWD and performs file mutations representing one SHA.
-# Returns CURRENT_SHA and TARGET_SHA via globals.
+# Builds a fresh git repo at <workdir> with two commits, echoes
+# "<current_sha> <target_sha>" to stdout. Caller should `read -r` it
+# into local vars via an intermediate variable so `set -e` propagates.
 build_scenario() {
   local workdir="$1" current_fn="$2" target_fn="$3"
   rm -rf "$workdir"
@@ -31,13 +35,13 @@ build_scenario() {
     "$current_fn"
     git add -A
     git commit -q --allow-empty -m "current"
-    CURRENT_SHA=$(git rev-parse HEAD)
+    local current; current=$(git rev-parse HEAD)
     "$target_fn"
     git add -A
     # Allow empty in case target_fn only deletes
     git commit -q --allow-empty -m "target"
-    TARGET_SHA=$(git rev-parse HEAD)
-    echo "$CURRENT_SHA $TARGET_SHA"
+    local target; target=$(git rev-parse HEAD)
+    echo "$current $target"
   )
 }
 
@@ -48,8 +52,9 @@ build_scenario() {
 run_detect() {
   local workdir="$1" current="$2" target="$3" input="$4"
   local removed="${5:-[]}" added="${6:-[]}"
-  local out
-  out=$(mktemp)
+  local out err
+  out=$(mktemp -p "$TMPROOT")
+  err="$out.err"
   GITHUB_OUTPUT="$out" "$DETECT_SCRIPT" \
     --current-sha "$current" \
     --target-ref "$target" \
@@ -57,7 +62,7 @@ run_detect() {
     --input-stacks "$input" \
     --removed-files "$removed" \
     --added-files "$added" \
-    >/dev/null 2>&1 || {
+    >/dev/null 2>"$err" || {
       echo "::detect-script-failed::" >> "$out"
     }
   echo "$out"
@@ -74,6 +79,14 @@ read_output() {
 #        <expected_new_json> <output_file>
 assert_classifications() {
   local name="$1" exp_removed="$2" exp_existing="$3" exp_new="$4" out="$5"
+  if grep -q '^::detect-script-failed::' "$out" 2>/dev/null; then
+    echo "❌ $name (detect script exited non-zero)"
+    if [[ -s "$out.err" ]]; then
+      sed 's/^/   stderr: /' "$out.err" | head -3
+    fi
+    FAIL=$((FAIL+1)); FAILURES+=("$name")
+    return
+  fi
   local got_removed got_existing got_new
   got_removed=$(read_output "$out" removed_stacks)
   got_existing=$(read_output "$out" existing_stacks)
@@ -89,6 +102,9 @@ assert_classifications() {
     echo "   removed:  got=$got_removed  want=$exp_removed"
     echo "   existing: got=$got_existing want=$exp_existing"
     echo "   new:      got=$got_new      want=$exp_new"
+    if [[ -s "$out.err" ]]; then
+      sed 's/^/   stderr: /' "$out.err" | head -3
+    fi
     FAIL=$((FAIL+1))
     FAILURES+=("$name")
   fi


### PR DESCRIPTION
## Summary

- Adds a `.disabled` marker file mechanism so a stack can be disabled without deleting it. Touch `<stack>/.disabled` to disable, `git rm` to re-enable.
- Disable transitions piggyback on the existing removed-stack teardown path (`docker compose down` via the `Teardown removed stacks` step). Re-enable runs the normal new-stack deploy.
- `detect-stack-changes.sh` introduces an "effectively present at SHA" predicate with guards on both removed (CURRENT_SHA) and new (TARGET_SHA) detectors, correctly handling the born-disabled and delete-while-disabled regression cases.
- `Discover stacks` filters disabled directories from the active set and emits a new `disabled_stacks` job output, surfaced in the Discord embed and PR comment via a 🛑 line alongside the existing 🗑️ removed line.
- Adds a bash unit-test harness at `scripts/testing/test-detect-stack-changes.sh` covering all 8 transition table rows (8/8 passing).
- Caller-repo workflows require zero changes.

Design spec: `docs/superpowers/specs/2026-05-26-disabled-stacks-design.md`
Implementation plan: `docs/superpowers/plans/2026-05-26-disabled-stacks.md`

## Test Plan

- [x] `./scripts/testing/test-detect-stack-changes.sh` — 8/8 pass
- [x] `shellcheck scripts/deployment/*.sh scripts/testing/*.sh scripts/testing/fixtures/*.sh` — clean
- [x] `actionlint .github/workflows/*.yml` — clean
- [x] `yamllint --strict .github/workflows/*.yml` — clean
- [ ] **Manual smoke test against `docker-piwine-office` after merge:**
  - Touch `dozzle/.disabled`, commit, push. Verify Discord shows "🛑 Disabled stacks: dozzle", containers stopped on host, compose file still present on disk.
  - `git rm dozzle/.disabled`, commit, push. Verify dozzle classified as new, containers come back up, health check passes.