### PR TITLE
fix(deploy): don't wrap down/ps/logs compose calls in op run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,15 +235,14 @@ jobs:
         if: |
           steps.skip-gate.outputs.skipped == 'false'
           && env.HAS_REMOVED == 'true'
-        # NB: `down` is intentionally NOT wrapped in `op run`. This step runs
-        # pre-reset, so it reads the *previous* compose.env — which may still
-        # reference a 1Password item that's since been archived (e.g. the same
-        # commit that removes a stack also drops its now-orphaned vars). `op run`
-        # resolves the whole env-file up front and aborts on any dead ref, which
-        # would skip the teardown entirely and strand the removed stack's
-        # containers. `down` identifies resources by compose project label and
-        # needs no resolved secrets, so run it directly. Same rationale applies
-        # to every `down`/`ps`/`logs` call in this workflow — only `up` needs op run.
+        # `down`/`ps`/`logs` here (and throughout this workflow) intentionally
+        # skip `op run` — only `up` needs resolved secrets. Two reasons:
+        #  1. This step runs pre-reset, so it reads the *previous* compose.env;
+        #     if that still references a since-archived 1P item (e.g. a stack
+        #     removal that also drops its now-orphaned vars), `op run` aborts on
+        #     the dead ref and the teardown never runs, stranding the containers.
+        #  2. `down` targets by compose project label (default: the stack dir
+        #     name, same as `up`); callers set no COMPOSE_* vars, so no secrets.
         run: |
           set -euo pipefail
           for stack in $(echo "$REMOVED_STACKS" | jq -r '.[]'); do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,6 +235,15 @@ jobs:
         if: |
           steps.skip-gate.outputs.skipped == 'false'
           && env.HAS_REMOVED == 'true'
+        # NB: `down` is intentionally NOT wrapped in `op run`. This step runs
+        # pre-reset, so it reads the *previous* compose.env — which may still
+        # reference a 1Password item that's since been archived (e.g. the same
+        # commit that removes a stack also drops its now-orphaned vars). `op run`
+        # resolves the whole env-file up front and aborts on any dead ref, which
+        # would skip the teardown entirely and strand the removed stack's
+        # containers. `down` identifies resources by compose project label and
+        # needs no resolved secrets, so run it directly. Same rationale applies
+        # to every `down`/`ps`/`logs` call in this workflow — only `up` needs op run.
         run: |
           set -euo pipefail
           for stack in $(echo "$REMOVED_STACKS" | jq -r '.[]'); do
@@ -248,7 +257,7 @@ jobs:
             done
             if [[ -n "$compose_file" ]]; then
               echo "🛑 Stopping $stack"
-              op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose -f "$compose_file" down || echo "::warning::down failed for $stack"
+              docker compose -f "$compose_file" down || echo "::warning::down failed for $stack"
             else
               echo "::warning::compose file missing for removed stack $stack"
             fi
@@ -363,20 +372,20 @@ jobs:
             local lines="${FAILED_LOG_LINES:-50}"
             echo "::group::🔍 Diagnostics: $stack"
             echo "── docker compose ps -a ──"
-            op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose ps -a 2>&1 || true
+            docker compose ps -a 2>&1 || true
             local rows
-            rows=$(op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose ps -a --format json 2>/dev/null \
+            rows=$(docker compose ps -a --format json 2>/dev/null \
               | jq -rs '.[] | select(.Health=="unhealthy" or (.State=="exited" and (.ExitCode//0)!=0) or (.Health=="" and .State!="running" and .State!="exited")) | [.Service,.Name,.State,(.Health//""),((.ExitCode//0)|tostring)] | @tsv' 2>/dev/null || true)
             if [[ -z "$rows" ]]; then
               echo "── (no specific failing container identified; tailing all services) ──"
-              op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose logs --tail "$lines" --no-color 2>&1 || true
+              docker compose logs --tail "$lines" --no-color 2>&1 || true
             else
               while IFS=$'\t' read -r service name state health exit_code; do
                 [[ -z "$service" ]] && continue
                 echo "── ❌ $service (container=$name state=$state health=${health:-none} exit=$exit_code) ──"
                 docker inspect --format '{{if .State.Health}}healthcheck history:{{"\n"}}{{range $i,$h := .State.Health.Log}}  [#{{$i}}] exit={{$h.ExitCode}} start={{$h.Start}}{{"\n"}}    {{$h.Output}}{{"\n"}}{{end}}{{else}}(no healthcheck defined){{end}}' "$name" 2>/dev/null || true
                 echo "── container logs: $service (last $lines lines) ──"
-                op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose logs --tail "$lines" --no-color "$service" 2>&1 || true
+                docker compose logs --tail "$lines" --no-color "$service" 2>&1 || true
               done <<< "$rows"
             fi
             echo "::endgroup::"
@@ -444,7 +453,7 @@ jobs:
             [[ "$stack" =~ ^[a-zA-Z0-9._-]+$ ]] || { echo "::warning::skipping invalid stack: $stack"; continue; }
             cd "$LIVE_REPO_PATH/$stack" 2>/dev/null || continue
             echo "🧹 Tearing down failed existing stack $stack to clear recreate orphans"
-            op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose down || true
+            docker compose down || true
           done
 
       - name: Deploy new stacks
@@ -465,20 +474,20 @@ jobs:
             local lines="${FAILED_LOG_LINES:-50}"
             echo "::group::🔍 Diagnostics: $stack"
             echo "── docker compose ps -a ──"
-            op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose ps -a 2>&1 || true
+            docker compose ps -a 2>&1 || true
             local rows
-            rows=$(op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose ps -a --format json 2>/dev/null \
+            rows=$(docker compose ps -a --format json 2>/dev/null \
               | jq -rs '.[] | select(.Health=="unhealthy" or (.State=="exited" and (.ExitCode//0)!=0) or (.Health=="" and .State!="running" and .State!="exited")) | [.Service,.Name,.State,(.Health//""),((.ExitCode//0)|tostring)] | @tsv' 2>/dev/null || true)
             if [[ -z "$rows" ]]; then
               echo "── (no specific failing container identified; tailing all services) ──"
-              op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose logs --tail "$lines" --no-color 2>&1 || true
+              docker compose logs --tail "$lines" --no-color 2>&1 || true
             else
               while IFS=$'\t' read -r service name state health exit_code; do
                 [[ -z "$service" ]] && continue
                 echo "── ❌ $service (container=$name state=$state health=${health:-none} exit=$exit_code) ──"
                 docker inspect --format '{{if .State.Health}}healthcheck history:{{"\n"}}{{range $i,$h := .State.Health.Log}}  [#{{$i}}] exit={{$h.ExitCode}} start={{$h.Start}}{{"\n"}}    {{$h.Output}}{{"\n"}}{{end}}{{else}}(no healthcheck defined){{end}}' "$name" 2>/dev/null || true
                 echo "── container logs: $service (last $lines lines) ──"
-                op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose logs --tail "$lines" --no-color "$service" 2>&1 || true
+                docker compose logs --tail "$lines" --no-color "$service" 2>&1 || true
               done <<< "$rows"
             fi
             echo "::endgroup::"
@@ -536,7 +545,7 @@ jobs:
           for stack in $(echo "$NEW_STACKS" | jq -r '.[]'); do
             [[ "$stack" =~ ^[a-zA-Z0-9._-]+$ ]] || { echo "::warning::skipping invalid stack: $stack"; continue; }
             cd "$LIVE_REPO_PATH/$stack" 2>/dev/null || continue
-            op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose down || true
+            docker compose down || true
           done
 
       - name: Compute deploy summary outputs
@@ -593,20 +602,20 @@ jobs:
             local lines="${FAILED_LOG_LINES:-50}"
             echo "::group::🔍 Diagnostics: $stack"
             echo "── docker compose ps -a ──"
-            op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose ps -a 2>&1 || true
+            docker compose ps -a 2>&1 || true
             local rows
-            rows=$(op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose ps -a --format json 2>/dev/null \
+            rows=$(docker compose ps -a --format json 2>/dev/null \
               | jq -rs '.[] | select(.Health=="unhealthy" or (.State=="exited" and (.ExitCode//0)!=0) or (.Health=="" and .State!="running" and .State!="exited")) | [.Service,.Name,.State,(.Health//""),((.ExitCode//0)|tostring)] | @tsv' 2>/dev/null || true)
             if [[ -z "$rows" ]]; then
               echo "── (no specific failing container identified; tailing all services) ──"
-              op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose logs --tail "$lines" --no-color 2>&1 || true
+              docker compose logs --tail "$lines" --no-color 2>&1 || true
             else
               while IFS=$'\t' read -r service name state health exit_code; do
                 [[ -z "$service" ]] && continue
                 echo "── ❌ $service (container=$name state=$state health=${health:-none} exit=$exit_code) ──"
                 docker inspect --format '{{if .State.Health}}healthcheck history:{{"\n"}}{{range $i,$h := .State.Health.Log}}  [#{{$i}}] exit={{$h.ExitCode}} start={{$h.Start}}{{"\n"}}    {{$h.Output}}{{"\n"}}{{end}}{{else}}(no healthcheck defined){{end}}' "$name" 2>/dev/null || true
                 echo "── container logs: $service (last $lines lines) ──"
-                op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose logs --tail "$lines" --no-color "$service" 2>&1 || true
+                docker compose logs --tail "$lines" --no-color "$service" 2>&1 || true
               done <<< "$rows"
             fi
             echo "::endgroup::"
@@ -615,7 +624,7 @@ jobs:
           failed=()
           for stack in $(echo "$CRITICAL_STACKS" | jq -r '.[]'); do
             cd "$LIVE_REPO_PATH/$stack"
-            services=$(op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose ps -a --format json | jq -s '.')
+            services=$(docker compose ps -a --format json | jq -s '.')
             # Unhealthy if: explicit "unhealthy", non-running with no healthcheck (and not a clean one-shot exit),
             # or exited with non-zero code. Exited+0 is a one-shot success (e.g. alembic migrations gated via
             # service_completed_successfully) and must not fail the gate.
@@ -699,7 +708,7 @@ jobs:
             done
             if [[ -n "$compose_file" ]]; then
               echo "🛑 Tearing down new stack $stack before rollback"
-              op run --no-masking --env-file="$LIVE_REPO_PATH/compose.env" -- docker compose -f "$compose_file" down || echo "::warning::down failed for $stack"
+              docker compose -f "$compose_file" down || echo "::warning::down failed for $stack"
             fi
           done
 


### PR DESCRIPTION
## Problem

The **Teardown removed stacks** step runs *before* the `git reset --hard` (it needs the pre-reset compose files to tear down stacks the commit deleted). So it reads the **previous** `compose.env`.

When a commit both removes a stack **and** drops a now-orphaned var whose 1Password item was already archived, `op run` resolves the *entire* env-file up front, hits the dead ref, and **aborts before `docker compose down` runs**. Result:

- The removed stack's containers are never stopped.
- The failure is only a `::warning::down failed for <stack>`, so the deploy job stays **green**.
- CI can't self-heal on a re-run — `prepare` no longer detects the stack as removed (previous_sha == target), so the teardown step won't fire again. Cleanup then requires a manual `docker compose -p <stack> down` on the host.

This actually happened on `docker-zendc`: media/logging/librarymanager were left running ~38h after their "successful" removal deploy, because the pre-reset `compose.env` still referenced the long-archived `zendc-zencommand` item.

## Fix

`docker compose down` / `ps` / `logs` operate on already-created resources **by compose project label** and need no resolved secrets. Only `up` genuinely requires `op run` (it injects env into *new* containers). 

This strips `op run --env-file` from all **17 inline** `down`/`ps`/`logs` calls, leaving the **4** `up` calls wrapped. A `${VAR}` in a torn-down file simply resolves to empty (no `${VAR:?}` guards exist in any caller compose file; all networks are `external: true`, which `down` never removes), so teardown and failure-diagnostics no longer depend on `compose.env` being fully resolvable.

## Why this is safe / not a regression

Git history shows **no secrets-driven rationale** in any commit that introduced these wrapped calls:
- Diagnostics `ps`/`logs` (`8a812a3`) — a diagnostics feature; `op run` applied uniformly alongside the `up` in the same helper.
- Teardown/cleanup `down` (`301c863`, `406ed43`, self-hosted rewrite) — messages are about *clearing orphans*, never secrets.
- The adjacent `docker inspect` calls were already **un**wrapped — the author already knew label/name-based inspection needs no `op run`.

## Verification

- `yamllint --strict` ✅
- `actionlint` (includes shellcheck on `run:` blocks) ✅
- Only the 4 multiline `timeout … op run … -- \` + `docker compose up` calls retain `op run`; 0 inline wrapped calls remain.

Non-breaking (no input changes) — callers pick it up via Renovate's SHA-pin bump.

## Summary by Sourcery

Simplify deploy workflow Docker Compose interactions to avoid teardown failures caused by unresolved 1Password env references.

Enhancements:
- Remove 1Password `op run` wrapping from all Docker Compose `down`/`ps`/`logs` calls in the deploy workflow while keeping `up` calls wrapped for secret injection.
- Document in the deploy workflow why teardown and diagnostics steps run Compose commands directly without `op run` to ensure reliable stack cleanup.

CI:
- Adjust deploy GitHub Actions workflow so stack teardown and diagnostics no longer depend on resolving the `compose.env` via 1Password.